### PR TITLE
Fix error while creating qucik proposal and projects without category

### DIFF
--- a/app/core/components/CategorySelect.tsx
+++ b/app/core/components/CategorySelect.tsx
@@ -1,4 +1,3 @@
-import { Fragment, useState } from "react"
 import { useQuery } from "blitz"
 import Select from "@material-ui/core/Select"
 import MenuItem from "@material-ui/core/MenuItem"
@@ -7,6 +6,7 @@ import InputLabel from "@material-ui/core/InputLabel"
 import FormHelperText from "@material-ui/core/FormHelperText"
 import { Field } from "react-final-form"
 import getCategories from "app/categories/queries/getCategories"
+import { defaultCategory } from "app/core/utils/constants"
 
 interface CategorySelectProps {
   name: string
@@ -30,7 +30,7 @@ export function CategorySelect({ name, label, helperText }: CategorySelectProps)
               sx={{ width: 300 }}
               label={label}
               disabled={submitting}
-              defaultValue={input.value.name}
+              defaultValue={defaultCategory}
               onChange={(event) => {
                 const newValue = categories.find((item) => item.name === event.target.value)
                 input.onChange(newValue)

--- a/app/core/utils/constants.ts
+++ b/app/core/utils/constants.ts
@@ -1,1 +1,2 @@
 export const Draft = "Draft"
+export const defaultCategory = "Experiment"

--- a/app/projects/mutations/createProject.ts
+++ b/app/projects/mutations/createProject.ts
@@ -1,6 +1,7 @@
 import { resolver, Ctx } from "blitz"
 import db from "db"
 import { FullCreate } from "app/projects/validations"
+import { defaultCategory } from "app/core/utils/constants"
 
 export default resolver.pipe(
   resolver.zod(FullCreate),
@@ -10,7 +11,7 @@ export default resolver.pipe(
       data: {
         ...input,
         owner: { connect: { id: session.profileId } },
-        category: { connect: { name: input.category?.name } },
+        category: { connect: { name: input.category?.name || defaultCategory } },
         skills: {
           connect: input.skills,
         },


### PR DESCRIPTION
Fix trying to create a project without category, now we set "Experiment" as default in UI and backend

Bug fixes #56 
#### What does this PR do?

Permits creating the proposal (with Experiment as default)
Sets Experiment to default category in the projects page to avoid trying to create a project without category

#### Where should the reviewer start?

Changed files

#### How should this be manually tested?

Go to create project page
Select create quick proposal
Set the fields
Press Create project button
Res: the project should be created

Go to create project page
Select create detailed proposal
The selected category should be "Experiment"
Set the fields
Press Create project button
Res: the project should be created

Go to create project page
Select create detailed proposal
The selected category should be "Experiment"
Change the category
Set the fields
Press Create project button
Res: the project should be created
 
#### What are the relevant tickets?
#56 

#### Screenshots
Now the create full project page shows Experiment as the default category
![Screen Shot 2021-09-14 at 13 03 55](https://user-images.githubusercontent.com/46000487/133310198-9db1d79f-31ec-4d48-9d54-f03d0ec31374.png)

