### PR TITLE
Fix/search-query - #162 - Change search query to use LIKE instead of MATCH

### DIFF
--- a/app/projects/queries/searchProjects.ts
+++ b/app/projects/queries/searchProjects.ts
@@ -35,12 +35,12 @@ export default resolver.pipe(
     { search, category, skill, label, orderBy, skip = 0, take = 50 }: SearchProjectsInput,
     { session }: Ctx
   ) => {
-    const prefixSearch = search + "*"
+    const prefixSearch = "%" + search + "%"
     let where = Prisma.empty
 
     if (search && search !== "") {
       search !== "myProposals"
-        ? (where = Prisma.sql`${where} WHERE projects_idx match ${prefixSearch}`)
+        ? (where = Prisma.sql`${where} WHERE ((p.name || p.description || p.valueStatement || p.searchSkills) LIKE ${prefixSearch})`)
         : (where = Prisma.sql`${where} WHERE ownerId == ${session.profileId}`)
     }
 


### PR DESCRIPTION
#### What does this PR do?

- CHange the searchProjects query, when there is a query string, it uses LIKE instead of MATCH to look for results.

#### Where should the reviewer start?

The reviewer should:
- Perform several changes.

#### How should this be manually tested?

1. Pull the changes and run the project
2. Search using different query strings and validate that it works consistently

#### What are the relevant tickets?

#162 

### Aditional Notes

This is a temporary solution while we found a way to make FTS5 work consistently or migrate the service to a different solution (e.g. Elastic Search)
