### PR TITLE
Bug - #165 - Fixed error when working with FTS functions

### DIFF
--- a/db/search_indexes.sql
+++ b/db/search_indexes.sql
@@ -1,16 +1,16 @@
 CREATE VIRTUAL TABLE IF NOT EXISTS projects_idx USING fts5(id, name, description, valueStatement, searchSkills, content='Projects');
 
 CREATE TRIGGER IF NOT EXISTS projects_idx_i AFTER INSERT ON "Projects" BEGIN
-  INSERT INTO projects_idx(id, "name", "description", "valueStatement", "searchSkills") VALUES (new.id, new."name", new."description", new."valueStatement", new."searchSkills");
+  INSERT INTO projects_idx(rowid, id, "name", "description", "valueStatement", "searchSkills") VALUES (new.rowid, new.id, new."name", new."description", new."valueStatement", new."searchSkills");
 END;
 
 CREATE TRIGGER IF NOT EXISTS projects_idx_d AFTER DELETE ON "Projects" BEGIN
-  INSERT INTO projects_idx(projects_idx, id, "name", "description", "valueStatement", "searchSkills") VALUES('delete', old.id, old."name", old."description", old."valueStatement", old."searchSkills");
+  INSERT INTO projects_idx(projects_idx, rowid, id, "name", "description", "valueStatement", "searchSkills") VALUES ('delete', old.rowid, old.id, old."name", old."description", old."valueStatement", old."searchSkills");
 END;
 
 CREATE TRIGGER IF NOT EXISTS projects_idx_u AFTER UPDATE ON "Projects" BEGIN
-  INSERT INTO projects_idx(projects_idx, id, "name", "description", "valueStatement", "searchSkills") VALUES('delete', old.id, old."name", old."description", old."valueStatement", old."searchSkills");
-  INSERT INTO projects_idx(id, "name", "description", "valueStatement", "searchSkills") VALUES (new.id, new."name", new."description", new."valueStatement", new."searchSkills");
+  INSERT INTO projects_idx(projects_idx, rowid, id, "name", "description", "valueStatement", "searchSkills") VALUES ('delete', old.rowid, old.id, old."name", old."description", old."valueStatement", old."searchSkills");
+  INSERT INTO projects_idx(rowid, id, "name", "description", "valueStatement", "searchSkills") VALUES (new.rowid, new.id, new."name", new."description", new."valueStatement", new."searchSkills");
 END;
 -- this allows running queries like:
 -- select * from projects_idx where projects_idx match 'labs';
@@ -19,16 +19,16 @@ END;
 CREATE VIRTUAL TABLE IF NOT EXISTS profiles_idx USING fts5(id, "firstName", "lastName", "email", content='Profiles');
 
 CREATE TRIGGER IF NOT EXISTS profiles_idx_i AFTER INSERT ON "Profiles" BEGIN
-  INSERT INTO profiles_idx(id, "firstName", "lastName", "email") VALUES (new.id, new."firstName", new."lastName", new."email");
+  INSERT INTO profiles_idx(rowid, id, "firstName", "lastName", "email") VALUES (new.rowid, new.id, new."firstName", new."lastName", new."email");
 END;
 
 CREATE TRIGGER IF NOT EXISTS profiles_idx_d AFTER DELETE ON "Profiles" BEGIN
-  INSERT INTO profiles_idx(profiles_idx, id, "firstName", "lastName", "email") VALUES('delete', old.id, old."firstName", old."lastName", old."email");
+  INSERT INTO profiles_idx(profiles_idx, rowid, id, "firstName", "lastName", "email") VALUES ('delete', old.rowid, old.id, old."firstName", old."lastName", old."email");
 END;
 
 CREATE TRIGGER IF NOT EXISTS profiles_idx_u AFTER UPDATE ON "Profiles" BEGIN
-  INSERT INTO profiles_idx(profiles_idx, id, "firstName", "lastName", "email") VALUES('delete', old.id, old."firstName", old."lastName", old."email");
-  INSERT INTO profiles_idx(id, "firstName", "lastName", "email") VALUES (new.id, new."firstName", new."lastName", new."email");
+  INSERT INTO profiles_idx(profiles_idx, rowid, id, "firstName", "lastName", "email") VALUES ('delete', old.rowid, old.id, old."firstName", old."lastName", old."email");
+  INSERT INTO profiles_idx(rowid, id, "firstName", "lastName", "email") VALUES (new.rowid, new.id, new."firstName", new."lastName", new."email");
 END;
 -- this allows running queries like:
 -- select * from profiles_idx where profiles_idx match 'joaquin';

--- a/db/seeds.ts
+++ b/db/seeds.ts
@@ -442,6 +442,16 @@ const seed = async () => {
       department: "Engineering",
     },
   })
+  await db.profiles.upsert({
+    where: { email: "jorge.gc@wizeline.com" },
+    update: {},
+    create: {
+      email: "jorge.gc@wizeline.com",
+      firstName: "Jorge",
+      lastName: "Gonzalez",
+      department: "Engineering",
+    },
+  })
   await db.projects.upsert({
     where: { name: "Proposal Hunt" },
     update: {},


### PR DESCRIPTION
#### What does this PR do?

Fixes trigger definitions for FTS tables to avoid virtual tables corruption error

#### Where should the reviewer start?

db/search_indexes.sql

#### How should this be manually tested?

1. Follow README instructions from step 6 to 10
2. Go to New Proposal
3. Check "Add more details option"
4. Type any name in the "Add a contributor" field, now it doesn't throw the error

#### Any background context you want to provide?

The error was related to the DB triggers for Profiles and Projects tables to keep the data populated with their respective virtual tables for FTS functionality. The virtual table creation commands didn't specify the content_rowid option and neither did the INSERT inside the triggers have the **rowid** column, this caused inconsistence in the database every time the triggers got executed and therefor causing an SQLITE_CORRUPT_VTAB (267) error when using FTS5 functions like MATCH in queries.

Note: Since we don't have yet any delete option in the app, the only part of the code where we deleted profiles was in the `sync-all-from-wos` command the deleted the profiles created by the app seed, thats why we couldn't see that if we did't run that command.

#### What are the relevant tickets?

#165 
