### PR TITLE
Bug | #181 | Fix in proposal creation where the fields are cleared while submitting

### DIFF
--- a/app/core/components/Form/index.tsx
+++ b/app/core/components/Form/index.tsx
@@ -16,6 +16,7 @@ export interface FormProps<S extends z.ZodType<any, any>>
   fullWidthButton?: boolean
   onSubmit: FinalFormProps<z.infer<S>>["onSubmit"]
   initialValues?: FinalFormProps<z.infer<S>>["initialValues"]
+  disabled?: boolean
 }
 
 export function Form<S extends z.ZodType<any, any>>({
@@ -25,15 +26,17 @@ export function Form<S extends z.ZodType<any, any>>({
   fullWidthButton,
   initialValues,
   onSubmit,
+  disabled,
   ...props
 }: FormProps<S>) {
+  const { projectformType, ...validFormProps } = props
   return (
     <FinalForm
       initialValues={initialValues}
       validate={validateZodSchema(schema)}
       onSubmit={onSubmit}
       render={({ handleSubmit, submitting, submitError }) => (
-        <form onSubmit={handleSubmit} className="form" {...props}>
+        <form onSubmit={handleSubmit} className="form" {...validFormProps}>
           {/* Form fields supplied as children are rendered here */}
           {children}
 
@@ -49,7 +52,7 @@ export function Form<S extends z.ZodType<any, any>>({
                 style={fullWidthButton ? { width: "100%" } : {}}
                 className="primary"
                 type="submit"
-                disabled={submitting}
+                disabled={submitting || disabled}
               >
                 {submitText}
               </button>

--- a/app/pages/projects/create/index.tsx
+++ b/app/pages/projects/create/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react"
+import { Suspense, useMemo, useState } from "react"
 import { useRouter, useMutation, useSession, BlitzPage, Routes, Router } from "blitz"
 import Layout from "app/core/layouts/Layout"
 import GoBack from "app/core/layouts/GoBack"
@@ -12,20 +12,25 @@ export const NewProject = () => {
   const session = useSession()
   const router = useRouter()
   const [createProjectMutation] = useMutation(createProject)
+  const [savingProject, setSavingProject] = useState<boolean>(false)
 
-  const INIT_VAUES_PROJECTFORM = {
-    skills: [],
-    labels: [],
-    // add current profile as default member
-    projectMembers: InitialMembers(session.profileId),
-  }
+  const INIT_VAUES_PROJECTFORM = useMemo(() => {
+    return {
+      skills: [],
+      labels: [],
+      // add current profile as default member
+      projectMembers: InitialMembers(session.profileId),
+    }
+  }, [session])
 
   const projectFormOnSubmit = async (values) => {
+    setSavingProject(true)
     try {
       const project = await createProjectMutation(values)
       router.push(Routes.ShowProjectPage({ projectId: project.id }))
     } catch (error) {
       console.error(error)
+      setSavingProject(false)
       return {
         [FORM_ERROR]: error.toString(),
       }
@@ -46,6 +51,7 @@ export const NewProject = () => {
           initialValues={INIT_VAUES_PROJECTFORM}
           schema={FullCreate}
           onSubmit={projectFormOnSubmit}
+          disabled={savingProject}
         />
       </div>
     </div>

--- a/app/pages/style.css
+++ b/app/pages/style.css
@@ -56,11 +56,11 @@ button.primary.warning {
   color: #fff;
 }
 
-button.primary.warning:disabled {
+button.primary:disabled {
   opacity: 0.5;
 }
 
-button[disabled].primary.warning:hover {
+button[disabled].primary:hover {
   cursor: not-allowed !important;
 }
 


### PR DESCRIPTION
#### What does this PR do?

* Added memoization to initial field values to prevent react-final-form treating it as a different value and therefor reseting the modified fields
* Added a new property (backwards compatible) to the main form component to be able to manually disable the submit button and not only in submit duration
* Added a state to disable the form submit when creating a new proposal and only enable again if there is an error, else it remains disabled to prevent new submits while the page transition appears
* Changed styles to add low opacity and special cursor to all disabled buttons

#### Where should the reviewer start?

In proposal creation form

#### How should this be manually tested?

1. Click on "New proposal" from the top bar
2. Fill the form with the required fields
3. Submit the form
4. The form should remain with the input values and the submit button should be disabled


#### Any background context you want to provide?

Previously in form submit the text fields got cleared because the library we use doesn't memoize the initial values in order to ignore reference changes after form initialization. Since **INIT_VAUES_PROJECTFORM** was declared inside the component declaration, it becomes a different variable reference every time any state changes and the component gets rendered, so the library treated it as a different value and reseted the form to the same values again and we lost the typed values.

As a note, we could just have moved the variable declaration outside the component but since we needed the session value that can only be accessed through the Blitz component I opted to memoize the value to keep the same reference through every render. 

Concerning to the decision to add a special **disable** attribute to the main form component it is because this component only disables the submit button while submitting (therefor while processing the mutation) but after that the users could still experience some delay until they get redirected to the next page and in the meantime they could click on submit again and trigger a new proposal creation that would actually lead to an error since the original submit was already saved.


#### What are the relevant tickets?

Fixes #181 
