### PR TITLE
Disable category and status when user is not admin

### DIFF
--- a/app/core/components/InputSelect/index.tsx
+++ b/app/core/components/InputSelect/index.tsx
@@ -8,6 +8,7 @@ interface InputSelectProps {
   label: string
   helperText?: string
   margin?: "normal" | "none" | "dense" | undefined
+  disabled?: boolean
 }
 
 export const InputSelect = ({
@@ -17,6 +18,7 @@ export const InputSelect = ({
   label,
   helperText,
   margin,
+  disabled,
 }: InputSelectProps) => {
   return (
     <Field name={name}>
@@ -32,7 +34,7 @@ export const InputSelect = ({
               id={name}
               sx={{ width: 300 }}
               label={label}
-              disabled={submitting}
+              disabled={submitting || disabled}
               value={input.value.name ? input.value.name : defaultValue}
               onChange={(event) => {
                 const newValue = valuesList.find((item) => item.name === event.target.value)

--- a/app/core/components/ProposalCard/index.tsx
+++ b/app/core/components/ProposalCard/index.tsx
@@ -3,7 +3,6 @@ import { Link, Routes } from "blitz"
 import { CardActionArea, CardContent, Card } from "@mui/material"
 import EllipsisText from "app/core/components/EllipsisText"
 import ThumbUpIcon from "@mui/icons-material/ThumbUp"
-import { defaultStatus } from "../../utils/constants"
 import Image from "next/image"
 
 import { ProposalCardWrap } from "./ProposalCard.styles"

--- a/app/core/utils/constants.ts
+++ b/app/core/utils/constants.ts
@@ -1,4 +1,5 @@
 export const defaultStatus = "Draft"
+export const adminRoleName = "ADMIN"
 export const defaultCategory = "Experiment"
 export const contributorPath = [
   {

--- a/app/pages/projects/[projectId]/edit/index.tsx
+++ b/app/pages/projects/[projectId]/edit/index.tsx
@@ -19,6 +19,7 @@ import TabPanel from "app/projects/components/TabPanel.component"
 import { ProjectContributorsPathForm } from "app/projects/components/ProjectContributorsPathForm"
 import { TabStyles, EditPanelsStyles } from "app/projects/components/Styles/TabStyles.component"
 import { useCurrentUser } from "../../../../core/hooks/useCurrentUser"
+import { adminRoleName } from "app/core/utils/constants"
 
 export const EditProject = () => {
   const router = useRouter()
@@ -44,7 +45,7 @@ export const EditProject = () => {
   const [updateStageMutation] = useMutation(updateStages)
   const isTeamMember = useSessionUserIsProjectTeamMember(project)
 
-  if (!isTeamMember && user?.role !== "ADMIN") {
+  if (!isTeamMember && user?.role !== adminRoleName) {
     return <AccessDenied />
   }
 

--- a/app/pages/projects/[projectId]/index.tsx
+++ b/app/pages/projects/[projectId]/index.tsx
@@ -29,6 +29,7 @@ import { EditSharp, ThumbUpSharp, ThumbDownSharp } from "@mui/icons-material"
 import updateProjectMember from "app/projects/mutations/updateProjectMember"
 import ConfirmationModal from "app/core/components/ConfirmationModal"
 import { useCurrentUser } from "../../../core/hooks/useCurrentUser"
+import { adminRoleName } from "app/core/utils/constants"
 
 export const Project = () => {
   const projectId = useParam("projectId", "string")
@@ -83,7 +84,7 @@ export const Project = () => {
         <HeaderInfo>
           <div className="headerInfo--action">
             <div className="headerInfo--edit">
-              {(isTeamMember || user?.role === "ADMIN") && (
+              {(isTeamMember || user?.role === adminRoleName) && (
                 <Link href={Routes.EditProjectPage({ projectId: project.id })} passHref>
                   <EditButton>
                     <EditSharp />
@@ -160,7 +161,7 @@ export const Project = () => {
           </Grid>
         </DetailMoreHead>
       </div>
-      {(isTeamMember || user?.role === "ADMIN") && (
+      {(isTeamMember || user?.role === adminRoleName) && (
         <div className="wrapper">
           <Stages path={project.stages} viewMode={true} project={project} />
         </div>

--- a/app/projects/components/ProjectForm.tsx
+++ b/app/projects/components/ProjectForm.tsx
@@ -15,7 +15,8 @@ import TextEditor from "app/core/components/TextEditor"
 
 import getCategories from "app/categories/queries/getCategories"
 import getStatuses from "app/statuses/queries/getStatuses"
-import { defaultCategory, defaultStatus } from "app/core/utils/constants"
+import { defaultCategory, defaultStatus, adminRoleName } from "app/core/utils/constants"
+import { useCurrentUser } from "../../core/hooks/useCurrentUser"
 
 export { FORM_ERROR } from "app/core/components/Form"
 
@@ -38,6 +39,8 @@ export function ProjectForm<S extends z.ZodType<any, any>>(props: FormProps<S>) 
       name: `${data.firstName} ${data.lastName}`,
     }
   }
+
+  const user = useCurrentUser()
 
   return (
     <Form<S> {...props}>
@@ -95,6 +98,7 @@ export function ProjectForm<S extends z.ZodType<any, any>>(props: FormProps<S>) 
           defaultValue={defaultCategory}
           name="category"
           label="Category"
+          disabled={user?.role !== adminRoleName}
         />
         {projectformType !== "create" && (
           <InputSelect
@@ -102,6 +106,7 @@ export function ProjectForm<S extends z.ZodType<any, any>>(props: FormProps<S>) 
             defaultValue={defaultStatus}
             name="projectStatus"
             label="Status"
+            disabled={user?.role !== adminRoleName}
           />
         )}
         <SkillsSelect name="skills" label="Skills" />


### PR DESCRIPTION

<!-- PR title format: `<Feat|Bug|Test|Doc|Chore|Junk> - <tracker-number> - <Short description>` -->
<!-- Fill out this PR template to make it easier for reviewers to understand your code. Remove this comment and any unnecessary section. -->

#### What does this PR do?

Change behavior of input select to allow disable it
Change project edition to check if the user is an admin
Add ADMIN as a constant
Remove unnecessary code

#### Where should the reviewer start?

[app/core/components/InputSelect/index.tsx](https://github.com/wizeline/project-lab/compare/feat/OnlyAdminCanChangeCatAndStat?expand=1#diff-6fc3ac32642772265b9d6b861ac7c9b06742818fb37862592cbe8123379a585f)

[app/pages/projects/[projectId]/edit/index.tsx](https://github.com/wizeline/project-lab/compare/feat/OnlyAdminCanChangeCatAndStat?expand=1#diff-49dee860afb7faaa1b2d5af2fdd801b5a9e21c26761e2aaed3dd506dcf2c47eb)

#### How should this be manually tested?

1. Register a user as ADMIN
2. Go to the edit project page
3. Verify category is not disabled
4. Verifica status is not disabled
5. Make some changes to those fields
6. Save and have fun


1. Register a user as USER
2. Go to the edit project page
3. Verify category is disabled
4. Verifica status is disabled
5. You can change other fields
6. Save and have fun

#### Any background context you want to provide?

<!-- Add any information regarding the PR that the reviewers should know, if necessary. -->

#### What are the relevant tickets?

closes #212 
