### PR TITLE
Fix/admin edit access bug - #182

### DIFF
--- a/app/pages/projects/[projectId]/edit/index.tsx
+++ b/app/pages/projects/[projectId]/edit/index.tsx
@@ -54,6 +54,7 @@ export const EditProject = () => {
     try {
       const updated = await updateProjectMutation({
         id: project.id,
+        isAdmin: user?.role === adminRoleName,
         ...values,
       })
       await setQueryData(updated)
@@ -70,6 +71,7 @@ export const EditProject = () => {
     try {
       await updateStageMutation({
         id: project.id,
+        isAdmin: user?.role === adminRoleName,
         projectMembers: project.projectMembers,
         owner: project.owner,
         ...values,

--- a/app/projects/mutations/updateProject.ts
+++ b/app/projects/mutations/updateProject.ts
@@ -5,9 +5,9 @@ import { FullUpdate, validateIsTeamMember } from "app/projects/validations"
 export default resolver.pipe(
   resolver.zod(FullUpdate),
   resolver.authorize(),
-  async ({ id, ...data }, { session }: Ctx) => {
+  async ({ id, isAdmin, ...data }, { session }: Ctx) => {
     //validate if the user have permissions (team member or owner of the project)
-    validateIsTeamMember(session, data)
+    if (!isAdmin) validateIsTeamMember(session, data)
 
     let activeMembers: any = []
 

--- a/app/projects/mutations/updateStages.ts
+++ b/app/projects/mutations/updateStages.ts
@@ -7,15 +7,16 @@ const UpdateContributorPath = z.object({
   id: z.string(),
   owner: z.object({ id: z.string() }),
   projectMembers: z.array(z.object({ profileId: z.string() })),
+  isAdmin: z.boolean(),
   stages: ContributorPath,
 })
 
 export default resolver.pipe(
   resolver.zod(UpdateContributorPath),
   resolver.authorize(),
-  async ({ id, owner, projectMembers, stages }, { session }: Ctx) => {
+  async ({ id, owner, projectMembers, isAdmin, stages }, { session }: Ctx) => {
     //validate if the user have permissions (team member or owner of the project)
-    validateIsTeamMember(session, { owner, projectMembers })
+    if (!isAdmin) validateIsTeamMember(session, { owner, projectMembers })
 
     for (let index = 0; index < stages.length; index++) {
       const stage = stages[index] ? stages[index] : null

--- a/app/projects/validations.ts
+++ b/app/projects/validations.ts
@@ -113,6 +113,7 @@ export const ContributorPath = z.array(z.object(ContributorPathFields)).nonempty
 export const FullUpdate = z
   .object({
     id: z.string(),
+    isAdmin: z.boolean(),
     owner: z.object({ id: z.string() }),
     existedMembers: z.array(z.string()),
     ...FullFormFields,


### PR DESCRIPTION
#### What does this PR do?

This PR solves a bug regarding admins not being allowed to edit projects they don't belong to

#### How should this be manually tested?

1. Pull the changes and run the project
2. Go to Prisma Studio and modify the User table by changing his user role to ADMIN
3. Log out and log in to the app so it updates your role
4. Go to the home page and select any of the projects where the user is not a member
5. Go to the edit page, modify some fields and save