### PR TITLE
Feat | #224 | Adding owner to general info in project page

### DIFF
--- a/app/pages/projects/[projectId]/[projectId].styles.tsx
+++ b/app/pages/projects/[projectId]/[projectId].styles.tsx
@@ -70,6 +70,12 @@ export const DetailMoreHead = styled.div`
     display: inline-block;
     text-align: center;
   }
+
+  @media (max-width: 599px) {
+    .itemHeadValue {
+      margin-bottom: 18px;
+    }
+  }
 `
 
 export const Like = styled.div`

--- a/app/pages/projects/[projectId]/index.tsx
+++ b/app/pages/projects/[projectId]/index.tsx
@@ -109,7 +109,8 @@ export const Project = () => {
             <Grid
               item
               container
-              xs={6}
+              sm={6}
+              xs={12}
               spacing={1}
               alignItems="center"
               justifyContent="flex-start"
@@ -125,7 +126,8 @@ export const Project = () => {
             <Grid
               item
               container
-              xs={6}
+              sm={6}
+              xs={12}
               spacing={1}
               alignItems="center"
               justifyContent="flex-start"
@@ -141,7 +143,8 @@ export const Project = () => {
             <Grid
               item
               container
-              xs={6}
+              sm={6}
+              xs={12}
               spacing={1}
               alignItems="center"
               justifyContent="flex-start"
@@ -157,7 +160,8 @@ export const Project = () => {
             <Grid
               item
               container
-              xs={6}
+              sm={6}
+              xs={12}
               spacing={1}
               alignItems="center"
               justifyContent="flex-start"


### PR DESCRIPTION
#### What does this PR do?

* Adds owner name to general info in project page
* Changed the grid to 2 columns to have a better look
* Changed the Labels list component since the previous had no space between items and didn't feel like a list

#### Where should the reviewer start?

In any project page

#### How should this be manually tested?

Go to any project page and the owner should appear in the general information below the title section.

#### Any background context you want to provide?

When changing the layout (to 2 columns) to suit better the information I realized that the Labels list didn't have a real spacing style and they just aligned as a list because the space (a third of a column) pulled them to a new line, but with the new layout they aligned in the same row without any space.

![image](https://user-images.githubusercontent.com/95710023/155631849-6a51014b-5a15-483d-bf21-b80df34bfd76.png)

#### What are the relevant tickets?

Fixes #224 

#### Screenshots

Final look:

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/95710023/155631114-27407805-2697-4dae-ab75-e4aa57e0563d.png">
