### PR TITLE
Update DeleteButton.component.tsx

### DIFF
--- a/app/projects/components/DeleteButton.component.tsx
+++ b/app/projects/components/DeleteButton.component.tsx
@@ -19,7 +19,7 @@ const DeleteButton = (props) => {
   const deleteProposal = async () => {
     try {
       await props.deleteProjectMutation({ id: props.project.id })
-      props.router.push(Routes.ProjectsPage())
+      props.router.push(Routes.Home())
     } catch (error) {
       handleClose()
       console.log(error)


### PR DESCRIPTION
After deleting proposal redirect to home instead of the projects page

Bug - 256 - Incorrect redirection after deletion of a project

fixes #256 
#### What does this PR do?
Changes the page to redirect after deleting a project.


#### Where should the reviewer start?
https://github.com/wizeline/project-lab/commit/8425a1f32ca9be7fbb39ec5b9b24a7f4099db12a

#### How should this be manually tested?

1. Create a project
2. Go to project edition
3. Select the delete option
4. Capture delete information
5. Delete the project

The page should be the home page


