### PR TITLE
Change project details page

### DIFF
--- a/app/pages/projects/[projectId]/index.tsx
+++ b/app/pages/projects/[projectId]/index.tsx
@@ -1,6 +1,15 @@
 import { Suspense, useState } from "react"
 import Editor from "rich-markdown-editor"
-import { Link, useQuery, useParam, BlitzPage, useMutation, invalidateQuery, Routes } from "blitz"
+import {
+  Link,
+  useQuery,
+  useParam,
+  BlitzPage,
+  useMutation,
+  invalidateQuery,
+  Routes,
+  useSession,
+} from "blitz"
 import { Card, CardContent, Chip, Stack, Grid, Box, TextField, Button } from "@mui/material"
 import { useCurrentUser } from "app/core/hooks/useCurrentUser"
 import { useSessionUserIsProjectTeamMember } from "app/core/hooks/useSessionUserIsProjectTeamMember"
@@ -29,6 +38,7 @@ export const Project = () => {
   const [upvoteProjectMutation] = useMutation(upvoteProject)
   const isTeamMember = useSessionUserIsProjectTeamMember(project)
   const user = useCurrentUser()
+  const session = useSession()
   const [showJoinModal, setShowJoinModal] = useState<boolean>(false)
   const [showModal, setShowModal] = useState<boolean>(false)
   const [joinProjectButton, setJoinProjectButton] = useState<boolean>(false)
@@ -207,7 +217,9 @@ export const Project = () => {
                       disabled={savingVoteStatus}
                       onClick={() => handleVote(project.id)}
                     >
-                      {project.votes.length > 0 ? (
+                      {project.votes.filter((vote) => {
+                        return vote.profileId === session.profileId
+                      }).length > 0 ? (
                         <>
                           {"Unlike"}&nbsp;
                           <ThumbDownSharp />

--- a/app/projects/queries/getProject.ts
+++ b/app/projects/queries/getProject.ts
@@ -32,7 +32,7 @@ export default resolver.pipe(
           },
           orderBy: [{ position: "asc" }],
         },
-        votes: { where: { profileId: session.profileId } },
+        votes: { where: { projectId: id } },
       },
     })
 


### PR DESCRIPTION
Change the project details page to show the total number of votes

Bug #260 Project details page does not show the total number of votes

#### What does this PR do?

Changes the showed information on the project details page.

#### Where should the reviewer start?

https://github.com/wizeline/project-lab/compare/bug/260/showCorrectVotes?expand=1#diff-065a0e0681eda7337fa4e36dfec502d5a0dcf5ac5e653837c51f74b4f54e991c

#### How should this be manually tested?

We need to test this with two users in development env, a couple of people should vote a project and the details page should show the correct number of votes

#### Any background context you want to provide?

Found in the beta

#### What are the relevant tickets?

fixes #260 
