### PR TITLE
Fix - fix error on contributor path for admins

### DIFF
--- a/app/projects/components/Stages/Stages.tsx
+++ b/app/projects/components/Stages/Stages.tsx
@@ -73,8 +73,9 @@ const Stages = ({ project, path = [] }: ICareerPathComponentProps) => {
       >
         {path.map((pathItem) => {
           const { projectTasks, id: projectStageId } = pathItem
-
-          const finishedStage = isStagedCompleted(projectTasks, projectTeamMember.contributorPath)
+          const finishedStage = projectTeamMember
+            ? isStagedCompleted(projectTasks, projectTeamMember.contributorPath)
+            : false
 
           return (
             <Card


### PR DESCRIPTION
#### What does this PR do?

It fixes the issue regarding the app crashing when an admin try to access a proposal in which he is not a member of.

#### Where should the reviewer start?

In the main page

#### How should this be manually tested?

- Set yourself as an Admin
- Try to access any project where you are not a member. It should work fine.
- Try to access a project where you are a member, it should work fine as well.

#### What are the relevant tickets?

Fixes #279 

#### Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [X] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [ ] I reviewed existing Pull Requests before submitting mine.
