### PR TITLE
Remove sync from wos on run-test github workflow

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -54,8 +54,5 @@ jobs:
       - name: Add Test Data
         run: blitz db seed
 
-      - name: Sync Skills With Wizeline OS
-        run: yarn sync-all-from-wos
-
       - name: Run Build
         run: yarn build


### PR DESCRIPTION
I think it is not needed to sync all WOS data every time we test. This code is also on run-deploy.yml, so we would still be syncing with WOS for deployments.

It would be good to also test that the sync code is working, but we should also be deprecating that part to sync from data lake in the future: #283
