### PR TITLE
Add project member versions functionality

### DIFF
--- a/db/migrations/20220416135337_project_member_versions_CUSTOMIZED/migration.sql
+++ b/db/migrations/20220416135337_project_member_versions_CUSTOMIZED/migration.sql
@@ -1,0 +1,89 @@
+-- CreateTable
+CREATE TABLE "ProjectMembersVersions" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "projectId" TEXT NOT NULL,
+    "profileId" TEXT NOT NULL,
+    "hoursPerWeek" INTEGER,
+    "role" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "practicedSkills" TEXT,
+    FOREIGN KEY ("profileId") REFERENCES "Profiles" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY ("projectId") REFERENCES "Projects" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_ProjectMembers" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "projectId" TEXT NOT NULL,
+    "profileId" TEXT NOT NULL,
+    "hoursPerWeek" INTEGER,
+    "role" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    FOREIGN KEY ("profileId") REFERENCES "Profiles" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY ("projectId") REFERENCES "Projects" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_ProjectMembers" ("active", "hoursPerWeek", "id", "profileId", "projectId", "role") SELECT "active", "hoursPerWeek", "id", "profileId", "projectId", "role" FROM "ProjectMembers";
+DROP TABLE "ProjectMembers";
+ALTER TABLE "new_ProjectMembers" RENAME TO "ProjectMembers";
+CREATE INDEX "project_members_profile_id_idx" ON "ProjectMembers"("profileId");
+CREATE INDEX "project_members_project_id_idx" ON "ProjectMembers"("projectId");
+CREATE UNIQUE INDEX "project_members_project_id_profile_id_key" ON "ProjectMembers"("projectId", "profileId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;
+
+-- CreateIndex
+CREATE INDEX "project_members_v_project_id_profile_id_key" ON "ProjectMembersVersions"("projectId", "profileId");
+
+-- CreateIndex
+CREATE INDEX "project_members_v_profile_id_idx" ON "ProjectMembersVersions"("profileId");
+
+-- CreateIndex
+CREATE INDEX "project_members_v_project_id_idx" ON "ProjectMembersVersions"("projectId");
+
+--- Manually added
+CREATE TRIGGER IF NOT EXISTS "project_members_v_insert" AFTER INSERT ON "ProjectMembers" BEGIN
+    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
+    VALUES (new.projectId, new.profileId, new.hoursPerWeek, new.role, new.active, "");
+END;
+
+CREATE TRIGGER IF NOT EXISTS "project_members_v_update" AFTER UPDATE ON "ProjectMembers" BEGIN
+    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
+    VALUES (new.projectId, new.profileId, new.hoursPerWeek, new.role, new.active, "");
+END;
+
+CREATE TRIGGER IF NOT EXISTS "project_members_v_delete" AFTER DELETE ON "ProjectMembers" BEGIN
+    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
+    VALUES (old.projectId, old.profileId, 0, "", false, "");
+END;
+
+--- Manually update practicedSkills field
+CREATE TRIGGER IF NOT EXISTS "practiced_skills_v_insert" AFTER INSERT ON "_ProjectMembersToSkills" BEGIN
+    UPDATE "ProjectMembersVersions"
+    SET
+      "updatedAt" = CURRENT_TIMESTAMP,
+      "practicedSkills" = (SELECT GROUP_CONCAT("B") FROM "_ProjectMembersToSkills" WHERE "A" = new.A)
+    WHERE id = (
+      SELECT v.id FROM ProjectMembers pm
+      INNER JOIN ProjectMembersVersions v ON pm.profileId = v.profileId AND pm.projectId = v.projectId
+      WHERE pm.id = new.A
+      ORDER BY v.createdAt DESC LIMIT 1
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS "practiced_skills_v_update" AFTER UPDATE ON "_ProjectMembersToSkills" BEGIN
+    UPDATE "ProjectMembersVersions"
+    SET
+      "updatedAt" = CURRENT_TIMESTAMP,
+      "practicedSkills" = (SELECT GROUP_CONCAT("B") FROM "_ProjectMembersToSkills" WHERE "A" = new.A)
+    WHERE id = (
+      SELECT v.id FROM ProjectMembers pm
+      INNER JOIN ProjectMembersVersions v ON pm.profileId = v.profileId AND pm.projectId = v.projectId
+      WHERE pm.id = new.A
+      ORDER BY v.createdAt DESC LIMIT 1
+    );
+END;

--- a/db/migrations/20220417031606_project_members_versions_customized/migration.sql
+++ b/db/migrations/20220417031606_project_members_versions_customized/migration.sql
@@ -13,6 +13,33 @@ CREATE TABLE "ProjectMembersVersions" (
     FOREIGN KEY ("projectId") REFERENCES "Projects" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+-- CreateTable
+CREATE TABLE "ProjectsVersions" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "ownerId" TEXT,
+    "name" TEXT NOT NULL,
+    "logo" TEXT,
+    "description" TEXT,
+    "valueStatement" TEXT,
+    "target" TEXT,
+    "demo" TEXT,
+    "repoUrl" TEXT,
+    "slackChannel" TEXT,
+    "isApproved" BOOLEAN NOT NULL DEFAULT false,
+    "status" TEXT DEFAULT 'Idea Submitted',
+    "categoryName" TEXT DEFAULT 'Experimenter',
+    "positions" TEXT,
+    "searchSkills" TEXT NOT NULL DEFAULT '',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "membersCount" INTEGER NOT NULL DEFAULT 0,
+    "votesCount" INTEGER NOT NULL DEFAULT 0,
+    "isArchived" BOOLEAN NOT NULL DEFAULT false,
+    FOREIGN KEY ("ownerId") REFERENCES "Profiles" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY ("status") REFERENCES "ProjectStatus" ("name") ON DELETE SET NULL ON UPDATE CASCADE,
+    FOREIGN KEY ("categoryName") REFERENCES "Category" ("name") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
 -- RedefineTables
 PRAGMA foreign_keys=OFF;
 CREATE TABLE "new_ProjectMembers" (
@@ -45,7 +72,47 @@ CREATE INDEX "project_members_v_profile_id_idx" ON "ProjectMembersVersions"("pro
 -- CreateIndex
 CREATE INDEX "project_members_v_project_id_idx" ON "ProjectMembersVersions"("projectId");
 
---- Manually added
+-- CreateIndex
+CREATE INDEX "projects_version_owner_id_idx" ON "ProjectsVersions"("ownerId");
+
+-- CreateIndex
+CREATE INDEX "projects_version_status_idx" ON "ProjectsVersions"("status");
+
+-- CreateIndex
+CREATE INDEX "projects_version_category_idx" ON "ProjectsVersions"("categoryName");
+
+-- CreateIndex
+CREATE INDEX "projects_version_isArchived_idx" ON "ProjectsVersions"("isArchived");
+
+--- Manually added for ProjectsVersions
+CREATE TRIGGER IF NOT EXISTS "projects_v_insert" AFTER INSERT ON "Projects" BEGIN
+    INSERT INTO "ProjectsVersions" ("ownerId", "name", "logo", "description", "valueStatement", "target", "demo", "repoUrl", "slackChannel", "isApproved", "status", "categoryName", "positions", "searchSkills", "isArchived",
+      "membersCount", "votesCount")
+    VALUES (NEW.ownerId, NEW.name, NEW.logo, NEW.description, NEW.valueStatement, NEW.target, NEW.demo, NEW.repoUrl, NEW.slackChannel, NEW.isApproved, NEW.status, NEW.categoryName, NEW.positions, NEW.searchSkills, NEW.isArchived,
+      (SELECT COUNT(*) FROM ProjectMembers WHERE ProjectMembers.projectId = NEW.id),
+      (SELECT COUNT(*) FROM Vote WHERE Vote.projectId = NEW.id)
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS "projects_v_update" AFTER UPDATE ON "Projects" BEGIN
+    INSERT INTO "ProjectsVersions" ("ownerId", "name", "logo", "description", "valueStatement", "target", "demo", "repoUrl", "slackChannel", "isApproved", "status", "categoryName", "positions", "searchSkills", "isArchived",
+      "membersCount", "votesCount")
+    VALUES (NEW.ownerId, NEW.name, NEW.logo, NEW.description, NEW.valueStatement, NEW.target, NEW.demo, NEW.repoUrl, NEW.slackChannel, NEW.isApproved, NEW.status, NEW.categoryName, NEW.positions, NEW.searchSkills, NEW.isArchived,
+      (SELECT COUNT(*) FROM ProjectMembers WHERE ProjectMembers.projectId = NEW.id),
+      (SELECT COUNT(*) FROM Vote WHERE Vote.projectId = NEW.id)
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS "projects_v_delete" AFTER DELETE ON "Projects" BEGIN
+    INSERT INTO "ProjectsVersions" ("ownerId", "name", "logo", "description", "valueStatement", "target", "demo", "repoUrl", "slackChannel", "isApproved", "status", "categoryName", "positions", "searchSkills", "isArchived",
+      "membersCount", "votesCount")
+    VALUES (OLD.ownerId, OLD.name, OLD.logo, OLD.description, OLD.valueStatement, OLD.target, OLD.demo, OLD.repoUrl, OLD.slackChannel, OLD.isApproved, OLD.status, OLD.categoryName, OLD.positions, OLD.searchSkills, OLD.isArchived,
+      0,
+      0
+    );
+END;
+
+--- Manually added for ProjectMembersVersions
 CREATE TRIGGER IF NOT EXISTS "project_members_v_insert" AFTER INSERT ON "ProjectMembers" BEGIN
     INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
     VALUES (new.projectId, new.profileId, new.hoursPerWeek, new.role, new.active, "");

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -86,27 +86,28 @@ model ProfileSkills {
 }
 
 model Profiles {
-  id             String           @id @default(uuid())
-  email          String           @unique
-  firstName      String
-  lastName       String
-  searchCol      String?
-  avatarUrl      String?
-  locationId     String?
-  jobTitleId     String?
-  jobLevelTier   String?
-  jobLevelTitle  String?
-  department     String?
-  createdAt      DateTime         @default(now())
-  updatedAt      DateTime         @default(now())
-  terminatedAt   DateTime?
-  jobTitles      JobTitles?       @relation(fields: [jobTitleId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  locations      Locations?       @relation(fields: [locationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  profileSkills  ProfileSkills[]
-  projectMembers ProjectMembers[]
-  projects       Projects[]
-  votes          Vote[]
-  comments       Comments[]
+  id                     String                   @id @default(uuid())
+  email                  String                   @unique
+  firstName              String
+  lastName               String
+  searchCol              String?
+  avatarUrl              String?
+  locationId             String?
+  jobTitleId             String?
+  jobLevelTier           String?
+  jobLevelTitle          String?
+  department             String?
+  createdAt              DateTime                 @default(now())
+  updatedAt              DateTime                 @default(now())
+  terminatedAt           DateTime?
+  jobTitles              JobTitles?               @relation(fields: [jobTitleId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  locations              Locations?               @relation(fields: [locationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  profileSkills          ProfileSkills[]
+  projectMembers         ProjectMembers[]
+  projectMembersVersions ProjectMembersVersions[]
+  projects               Projects[]
+  votes                  Vote[]
+  comments               Comments[]
 
   @@index([email], name: "profiles_email_idx")
   @@index([jobTitleId], name: "profiles_job_title_id_idx")
@@ -116,6 +117,8 @@ model Profiles {
 
 model ProjectMembers {
   id              String            @id @default(uuid())
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @default(now())
   projectId       String
   profileId       String
   hoursPerWeek    Int?
@@ -131,6 +134,24 @@ model ProjectMembers {
   @@index([projectId], name: "project_members_project_id_idx")
 }
 
+model ProjectMembersVersions {
+  id              Int       @id @default(autoincrement())
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @default(now())
+  projectId       String
+  profileId       String
+  hoursPerWeek    Int?
+  role            String?
+  active          Boolean   @default(true)
+  profile         Profiles? @relation(fields: [profileId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  project         Projects? @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  practicedSkills String?
+
+  @@index([projectId, profileId], name: "project_members_v_project_id_profile_id_key")
+  @@index([profileId], name: "project_members_v_profile_id_idx")
+  @@index([projectId], name: "project_members_v_project_id_idx")
+}
+
 model ProjectStatus {
   name     String     @id
   color    String     @default("#1d1d1d")
@@ -143,33 +164,34 @@ model Category {
 }
 
 model Projects {
-  id             String           @id @default(uuid())
-  ownerId        String?
-  name           String           @unique
-  logo           String?
-  description    String?
-  valueStatement String?
-  target         String?
-  demo           String?
-  repoUrl        String?
-  slackChannel   String?
-  isApproved     Boolean          @default(false)
-  status         String?          @default("Idea Submitted")
-  categoryName   String?          @default("Experimenter")
-  positions      String?
-  searchSkills   String           @default("")
-  createdAt      DateTime         @default(now())
-  updatedAt      DateTime         @default(now())
-  owner          Profiles?        @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  projectStatus  ProjectStatus?   @relation(fields: [status], references: [name], onDelete: SetNull, onUpdate: Cascade)
-  category       Category?        @relation(fields: [categoryName], references: [name], onDelete: SetNull, onUpdate: Cascade)
-  projectMembers ProjectMembers[]
-  skills         Skills[]
-  labels         Labels[]
-  votes          Vote[]
-  comments       Comments[]
-  stages         ProjectStages[]
-  isArchived     Boolean          @default(false)
+  id                     String                   @id @default(uuid())
+  ownerId                String?
+  name                   String                   @unique
+  logo                   String?
+  description            String?
+  valueStatement         String?
+  target                 String?
+  demo                   String?
+  repoUrl                String?
+  slackChannel           String?
+  isApproved             Boolean                  @default(false)
+  status                 String?                  @default("Idea Submitted")
+  categoryName           String?                  @default("Experimenter")
+  positions              String?
+  searchSkills           String                   @default("")
+  createdAt              DateTime                 @default(now())
+  updatedAt              DateTime                 @default(now())
+  owner                  Profiles?                @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  projectStatus          ProjectStatus?           @relation(fields: [status], references: [name], onDelete: SetNull, onUpdate: Cascade)
+  category               Category?                @relation(fields: [categoryName], references: [name], onDelete: SetNull, onUpdate: Cascade)
+  projectMembers         ProjectMembers[]
+  projectMembersVersions ProjectMembersVersions[]
+  skills                 Skills[]
+  labels                 Labels[]
+  votes                  Vote[]
+  comments               Comments[]
+  stages                 ProjectStages[]
+  isArchived             Boolean                  @default(false)
 
   @@index([ownerId], name: "projects_owner_id_idx")
   @@index([status], name: "projects_status_idx")

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -106,6 +106,7 @@ model Profiles {
   projectMembers         ProjectMembers[]
   projectMembersVersions ProjectMembersVersions[]
   projects               Projects[]
+  projectsVersions       ProjectsVersions[]
   votes                  Vote[]
   comments               Comments[]
 
@@ -153,14 +154,16 @@ model ProjectMembersVersions {
 }
 
 model ProjectStatus {
-  name     String     @id
-  color    String     @default("#1d1d1d")
-  projects Projects[]
+  name             String             @id
+  color            String             @default("#1d1d1d")
+  projects         Projects[]
+  projectsVersions ProjectsVersions[]
 }
 
 model Category {
-  name     String     @id
-  projects Projects[]
+  name             String             @id
+  projects         Projects[]
+  projectsVersions ProjectsVersions[]
 }
 
 model Projects {
@@ -197,6 +200,37 @@ model Projects {
   @@index([status], name: "projects_status_idx")
   @@index([categoryName], name: "projects_category_idx")
   @@index([isArchived], name: "projects_isArchived_idx")
+}
+
+model ProjectsVersions {
+  id             Int            @id @default(autoincrement())
+  ownerId        String?
+  name           String
+  logo           String?
+  description    String?
+  valueStatement String?
+  target         String?
+  demo           String?
+  repoUrl        String?
+  slackChannel   String?
+  isApproved     Boolean        @default(false)
+  status         String?        @default("Idea Submitted")
+  categoryName   String?        @default("Experimenter")
+  positions      String?
+  searchSkills   String         @default("")
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @default(now())
+  membersCount   Int            @default(0)
+  votesCount     Int            @default(0)
+  isArchived     Boolean        @default(false)
+  owner          Profiles?      @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  projectStatus  ProjectStatus? @relation(fields: [status], references: [name], onDelete: SetNull, onUpdate: Cascade)
+  category       Category?      @relation(fields: [categoryName], references: [name], onDelete: SetNull, onUpdate: Cascade)
+
+  @@index([ownerId], name: "projects_version_owner_id_idx")
+  @@index([status], name: "projects_version_status_idx")
+  @@index([categoryName], name: "projects_version_category_idx")
+  @@index([isArchived], name: "projects_version_isArchived_idx")
 }
 
 model Vote {


### PR DESCRIPTION
This change modifies mainly two files:

- `db/schema.prisma`. Add the project members schema
- `db/migrations/20220416135337_project_member_versions_CUSTOMIZED/migration.sql`.
  Customize the migration file with SQL triggers to automate filling the versions table

#### Where should the reviewer start?

On the customized code of the migration.sql file.

#### How should this be manually tested?

Checkout this branch and run:

```bash
npx blitz prisma migrate reset
sqlite3 db/db.sqlite < db/search_indexes.sql
npx blitz db seed
```

Then query the new ProjectMembersVersions table and you should see it autofilled, even with practicedSkills joined.

#### What are the relevant tickets?

Closes #272 
