### PR TITLE
Fix - #290 -Remove autocomplete oninput change option

### DIFF
--- a/app/core/components/SkillsSelect/index.tsx
+++ b/app/core/components/SkillsSelect/index.tsx
@@ -41,8 +41,6 @@ export const SkillsSelect = ({
 
   const { skills } = data || { skills: [] }
 
-  const setSearchTermDebounced = debounce(setSearchTerm, 500)
-
   return (
     <Field name={name}>
       {({ input, meta: { touched, error, submitError, submitting } }) => {
@@ -60,7 +58,6 @@ export const SkillsSelect = ({
               filterSelectedOptions
               isOptionEqualToValue={(option, value) => option.name === value.name}
               getOptionLabel={(option) => option.name}
-              onInputChange={(_, value) => setSearchTermDebounced(value)}
               value={input.value ? input.value : defaultValue}
               onChange={(_, value) => {
                 input.onChange(value)

--- a/app/pages/projects/[projectId]/ProjectConfirmationModal.tsx
+++ b/app/pages/projects/[projectId]/ProjectConfirmationModal.tsx
@@ -74,7 +74,7 @@ const ProjectConfirmationModal = ({
       )
     } else if (member.active) {
       // In case any NO OWNER member leaves...
-      title = "We're sorry you're leaving the projec"
+      title = "We're sorry you're leaving the project"
       content =
         "By confirming you will be inactive for this project but you can join again at anytime."
     } else {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue regarding the Skills field being cleared after the user types something without selecting anything

#### Where should the reviewer start?

In the join project modal

#### How should this be manually tested?

- Pull the changes and run the project
- Try to join a project
- In the skills field, type anything and confirm that the field is not cleared out.

#### Any background context you want to provide?

based on the MUI [documentation](https://mui.com/material-ui/react-autocomplete/#controlled-states), the Autocomplete `onInputChange` option is useful when we want to manage a state based on the field value, but in this case, we are using that prop to do a Search Debounce, so it is not the ideal use case. Also, all the option are fetched in the first render, and the Autocomplete component does the filter automatically based on the input, so that debounce is doing unnecessary calls to the backend, that are triggering a new render of the component and hence erasing the input.

Let's test with this field that everything goes fine in develop, and it does, I will change all the other Autocomplete components in a separate PR

#### What are the relevant tickets?

#290 

P.S. I also fixed a small typo in the leaving confirmation modal