### PR TITLE
Fix - #290 -Remove autocomplete on input change option

### DIFF
--- a/app/core/components/SkillsSelect/index.tsx
+++ b/app/core/components/SkillsSelect/index.tsx
@@ -57,6 +57,7 @@ export const SkillsSelect = ({
               disabled={submitting}
               loading={isLoading || !data}
               options={skills}
+              filterOptions={(x) => x}
               filterSelectedOptions
               isOptionEqualToValue={(option, value) => option.name === value.name}
               getOptionLabel={(option) => option.name}

--- a/app/pages/projects/[projectId]/ProjectConfirmationModal.tsx
+++ b/app/pages/projects/[projectId]/ProjectConfirmationModal.tsx
@@ -74,7 +74,7 @@ const ProjectConfirmationModal = ({
       )
     } else if (member.active) {
       // In case any NO OWNER member leaves...
-      title = "We're sorry you're leaving the project"
+      title = "Come back soon!"
       content =
         "By confirming you will be inactive for this project but you can join again at anytime."
     } else {

--- a/app/pages/projects/[projectId]/ProjectConfirmationModal.tsx
+++ b/app/pages/projects/[projectId]/ProjectConfirmationModal.tsx
@@ -74,7 +74,7 @@ const ProjectConfirmationModal = ({
       )
     } else if (member.active) {
       // In case any NO OWNER member leaves...
-      title = "We're sorry you're leaving the projec"
+      title = "We're sorry you're leaving the project"
       content =
         "By confirming you will be inactive for this project but you can join again at anytime."
     } else {

--- a/app/projects/components/joinProjectModal/index.tsx
+++ b/app/projects/components/joinProjectModal/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { z } from "zod"
 import { Form } from "app/core/components/Form"
 import LabeledTextField from "app/core/components/LabeledTextField"
@@ -21,12 +21,24 @@ export const JoinFields = z.object({
   hoursPerWeek: z.string().refine((val) => !val || /^\d+$/.test(val), {
     message: "Value must be an integer",
   }),
-  practicedSkills: z.array(z.any()),
+  practicedSkills: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+    })
+  ),
 })
 
 const JoinProjectModal = (props: IProps) => {
   const router = useRouter()
   const { createProjectMemberHandler } = useProjectMembers()
+
+  const INIT_VALUES_MODALFORM = useMemo(() => {
+    return {
+      practicedSkills: [],
+    }
+  }, [])
+
   return (
     <ModalBox
       open={props.open}
@@ -51,6 +63,7 @@ const JoinProjectModal = (props: IProps) => {
             console.error(error)
           }
         }}
+        initialValues={INIT_VALUES_MODALFORM}
       >
         <Grid>
           <FormDivContainer>


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue regarding the Skills field being cleared after the user types something without selecting anything

#### Where should the reviewer start?

In the join project modal

#### How should this be manually tested?

- Pull the changes and run the project
- Try to join a project
- In the skills field, type anything and confirm that the field is not cleared out.

#### Any background context you want to provide?

I don't have a clear understanding of the root cause, but I think it was because as the skillSelect input wasn't set with initial values in the form, it was being managed as an uncontrolled component by React, and hence it was having an strange behavior, when you selected an option from the Autocomplete menu then the component became controlled and React was able to manage it. This is an idea I have about the RC, but at least it is working fine now, I just had to add the initial values to the Form for the sillsSelect component and that's it.

#### What are the relevant tickets?

#290 

P.S. I also fixed a small typo in the leaving confirmation modal
