### PR TITLE
Fix - #312 - split the skills ids in several arrays for the deletemany transaction

### DIFF
--- a/tasks/types/ProfileWOSDTO.ts
+++ b/tasks/types/ProfileWOSDTO.ts
@@ -11,4 +11,5 @@ export default class ProfileWOSDTO {
   terminatedAt?: string
   locationId: string
   constructor() {}
+  deleted: boolean
 }

--- a/test/syncAllDataFromWOS.test.ts
+++ b/test/syncAllDataFromWOS.test.ts
@@ -50,6 +50,7 @@ const mockDataProviderGetProfilesFromWizelineOS = jest.fn((): Promise<ProfileWOS
       jobLevelTier: "string",
       department: "string",
       locationId: "locationId",
+      deleted: false,
     },
   ])
 })
@@ -104,6 +105,7 @@ const mockDataProviderUpdatedGetProfilesFromWizelineOS = jest.fn((): Promise<Pro
       jobLevelTier: "string",
       department: "string",
       locationId: "locationId",
+      deleted: false,
     },
   ])
 })


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the error thrown by the `sync-all-from-wos` regarding the Query parameter limit exceeded error. I divided the skills in several arrays and then it executes a `deleteMany` per array.

I also added `deleted` column to the `ProfileWOSDTO` as the test was failing because of it

#### Where should the reviewer start?

The reviewer should check the `sync-all-from-wos.ts`

#### How should this be manually tested?

- Pull the changes
- run `yarn sync-all-from-wos.ts`script
- Validate everything is working fine in the DB (You can use Prisma Sudio for it)

#### What are the relevant tickets?

#312 

#### Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [X] I added the necessary documentation, if appropriate.
- [X] I added tests to prove that my fix is effective or my feature works.
- [X] I reviewed existing Pull Requests before submitting mine.