### PR TITLE
help wanted field

### DIFF
--- a/app/core/components/LabeledSwitchField/index.tsx
+++ b/app/core/components/LabeledSwitchField/index.tsx
@@ -1,0 +1,24 @@
+import { Field, FieldRenderProps } from "react-final-form"
+import { Checkbox, FormControlLabel, Switch } from "@mui/material"
+
+interface LabeledSwitchFieldProps {
+  name: string
+  label: string
+  initialValues?: boolean
+}
+type Props = FieldRenderProps<boolean, any>
+
+const CheckboxInput: React.FC<Props> = ({ input: { value, ...input } }: Props) => (
+  <Switch {...input} defaultChecked={input.initialValue} />
+)
+
+export const LabeledSwitchField = ({ label, name, initialValues }: LabeledSwitchFieldProps) => {
+  return (
+    <FormControlLabel
+      label={label}
+      control={<Field name={name} component={CheckboxInput} type="checkbox" />}
+    />
+  )
+}
+
+export default LabeledSwitchField

--- a/app/pages/projects/[projectId]/index.tsx
+++ b/app/pages/projects/[projectId]/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from "react"
+import { Fragment, Suspense, useState } from "react"
 import Editor from "rich-markdown-editor"
 import {
   Link,
@@ -336,10 +336,12 @@ export const Project = () => {
                 >
                   {member?.active ? "Suspend my Membership" : "Join Project Again"}
                 </Button>
-              ) : (
+              ) : project.helpWanted ? (
                 <Button className="primary large" onClick={handleJoinProject}>
                   Want to Join?
                 </Button>
+              ) : (
+                <Fragment> </Fragment>
               )}
             </Stack>
           </Grid>

--- a/app/pages/projects/create/index.tsx
+++ b/app/pages/projects/create/index.tsx
@@ -20,6 +20,7 @@ export const NewProject = () => {
       labels: [],
       // add current profile as default member
       projectMembers: InitialMembers(session),
+      helpWanted: true,
     }
   }, [session])
 

--- a/app/projects/components/ProjectForm.tsx
+++ b/app/projects/components/ProjectForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { useQuery } from "blitz"
-import { FormControlLabel, Switch, Collapse } from "@mui/material"
+import { FormControlLabel, Switch, Collapse, Checkbox } from "@mui/material"
 import { z } from "zod"
 
 import { Form, FormProps } from "app/core/components/Form"
@@ -18,8 +18,8 @@ import getCategories from "app/categories/queries/getCategories"
 import getStatuses from "app/statuses/queries/getStatuses"
 import { defaultCategory, defaultStatus, adminRoleName } from "app/core/utils/constants"
 import { useCurrentUser } from "../../core/hooks/useCurrentUser"
-import { TireRepairSharp } from "@mui/icons-material"
 import getInnovationTiers from "app/innovationTiers/queries/getInnovationTiers"
+import { LabeledSwitchField } from "app/core/components/LabeledSwitchField"
 
 export { FORM_ERROR } from "app/core/components/Form"
 
@@ -63,6 +63,11 @@ export function ProjectForm<S extends z.ZodType<any, any>>(props: FormProps<S>) 
         label="Your proposal"
         placeholder="Explain us your proposal..."
       ></TextEditor>
+      <LabeledSwitchField
+        name="helpWanted"
+        label="Help wanted"
+        initialValues={initialValues ? initialValues.helpWanted : true}
+      />
 
       {projectformType === "create" && (
         <FormControlLabel

--- a/app/projects/validations.ts
+++ b/app/projects/validations.ts
@@ -78,6 +78,7 @@ export const FullFormFields = {
     .optional(),
   projectMembers,
   innovationTiers: z.object({ name: z.string() }).optional(),
+  helpWanted: z.boolean().optional(),
 }
 
 const extractSearchSkills = (val) => {

--- a/db/migrations/20220511212320_project_help_wanted/migration.sql
+++ b/db/migrations/20220511212320_project_help_wanted/migration.sql
@@ -1,0 +1,75 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Projects" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "ownerId" TEXT,
+    "name" TEXT NOT NULL,
+    "logo" TEXT,
+    "description" TEXT,
+    "valueStatement" TEXT,
+    "target" TEXT,
+    "demo" TEXT,
+    "repoUrl" TEXT,
+    "slackChannel" TEXT,
+    "isApproved" BOOLEAN NOT NULL DEFAULT false,
+    "status" TEXT DEFAULT 'Idea Submitted',
+    "categoryName" TEXT DEFAULT 'Experimenter',
+    "tierName" TEXT DEFAULT 'Tier 3 (Experiment)',
+    "positions" TEXT,
+    "searchSkills" TEXT NOT NULL DEFAULT '',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isArchived" BOOLEAN NOT NULL DEFAULT false,
+    "helpWanted" BOOLEAN NOT NULL DEFAULT true,
+    CONSTRAINT "Projects_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Profiles" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Projects_status_fkey" FOREIGN KEY ("status") REFERENCES "ProjectStatus" ("name") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Projects_categoryName_fkey" FOREIGN KEY ("categoryName") REFERENCES "Category" ("name") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Projects_tierName_fkey" FOREIGN KEY ("tierName") REFERENCES "InnovationTiers" ("name") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Projects" ("categoryName", "createdAt", "demo", "description", "id", "isApproved", "isArchived", "logo", "name", "ownerId", "positions", "repoUrl", "searchSkills", "slackChannel", "status", "target", "tierName", "updatedAt", "valueStatement") SELECT "categoryName", "createdAt", "demo", "description", "id", "isApproved", "isArchived", "logo", "name", "ownerId", "positions", "repoUrl", "searchSkills", "slackChannel", "status", "target", "tierName", "updatedAt", "valueStatement" FROM "Projects";
+DROP TABLE "Projects";
+ALTER TABLE "new_Projects" RENAME TO "Projects";
+CREATE UNIQUE INDEX "Projects_name_key" ON "Projects"("name");
+CREATE INDEX "projects_owner_id_idx" ON "Projects"("ownerId");
+CREATE INDEX "projects_status_idx" ON "Projects"("status");
+CREATE INDEX "projects_category_idx" ON "Projects"("categoryName");
+CREATE INDEX "projects_isArchived_idx" ON "Projects"("isArchived");
+CREATE INDEX "projects_innovation_tier_idx" ON "Projects"("tierName");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;
+
+-- RedefineIndex
+DROP INDEX "Disciplines.name_unique";
+CREATE UNIQUE INDEX "Disciplines_name_key" ON "Disciplines"("name");
+
+-- RedefineIndex
+DROP INDEX "Labels.name_unique";
+CREATE UNIQUE INDEX "Labels_name_key" ON "Labels"("name");
+
+-- RedefineIndex
+DROP INDEX "Locations.name_unique";
+CREATE UNIQUE INDEX "Locations_name_key" ON "Locations"("name");
+
+-- RedefineIndex
+DROP INDEX "Profiles.email_unique";
+CREATE UNIQUE INDEX "Profiles_email_key" ON "Profiles"("email");
+
+-- RedefineIndex
+DROP INDEX "project_members_project_id_profile_id_key";
+CREATE UNIQUE INDEX "ProjectMembers_projectId_profileId_key" ON "ProjectMembers"("projectId", "profileId");
+
+-- RedefineIndex
+DROP INDEX "Session.handle_unique";
+CREATE UNIQUE INDEX "Session_handle_key" ON "Session"("handle");
+
+-- RedefineIndex
+DROP INDEX "Token.hashedToken_type_unique";
+CREATE UNIQUE INDEX "Token_hashedToken_type_key" ON "Token"("hashedToken", "type");
+
+-- RedefineIndex
+DROP INDEX "User.email_unique";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- RedefineIndex
+DROP INDEX "Vote.projectId_profileId_unique";
+CREATE UNIQUE INDEX "Vote_projectId_profileId_key" ON "Vote"("projectId", "profileId");

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -186,6 +186,7 @@ model Projects {
   comments               Comments[]
   stages                 ProjectStages[]
   isArchived             Boolean                  @default(false)
+  helpWanted             Boolean                  @default(true)
 
   @@index([ownerId], name: "projects_owner_id_idx")
   @@index([status], name: "projects_status_idx")


### PR DESCRIPTION

`<Feat> - 225 - Help wanted` 
The project should have a flag to identify if new members are required, and the join project button should be enabled or disabled according to the flag

Decided to hide the button to avoid grey areas in the UI

#### What does this PR do?

Adds a new boolean field to projects (helpWanted)
The field can be assigned while project creation
The field can be changed while project updating
If a project does not allow new members (helpWanted is false) then the Want to join? button is not shown

#### Where should the reviewer start?

Any file

#### How should this be manually tested?

Create a project and verify the field helpWanted can be changed and the final value is persisted in DB
Update a project and verify the field helpWanted can be changed and the final value is persisted in DB
Modify a project so the value of helpWanted is false, then not being a member consult the project information, the want to join button should not appear.


#### What are the relevant tickets?

fixes  #225  
