### PR TITLE
Don't require the SSH_PRIVATE_KEY variable

### DIFF
--- a/.github/workflows/run-deploy.yaml
+++ b/.github/workflows/run-deploy.yaml
@@ -112,7 +112,7 @@ jobs:
 
       - id: get-lightsail-ssh-key
         name: Get Lightsail Private SSH Key
-        run: mkdir ~/.ssh && aws lightsail download-default-key-pair --profile ${{ steps.repo-name.outputs.REPO_NAME }} | jq '.privateKeyBase64' | tr -d '"' | sed 's/\\n/\n/g' > ~/.ssh/lightsail.pem
+        run: mkdir ~/.ssh && aws lightsail download-default-key-pair | jq '.privateKeyBase64' | tr -d '"' | sed 's/\\n/\n/g' > ~/.ssh/lightsail.pem
 
       - name: Prepare Server For Build
         uses: appleboy/ssh-action@master

--- a/.github/workflows/run-deploy.yaml
+++ b/.github/workflows/run-deploy.yaml
@@ -110,12 +110,16 @@ jobs:
         name: Get Lightsail Instance IP Address
         run: echo ::set-output name=IP_ADDRESS::$(aws lightsail get-instance-access-details --instance-name project-lab-${{ steps.get-branch.outputs.branch }} | jq -r '.accessDetails.ipAddress')
 
+      - id: get-lightsail-ssh-key
+        name: Get Lightsail Private SSH Key
+        run: mkdir ~/.ssh && aws lightsail download-default-key-pair --profile ${{ steps.repo-name.outputs.REPO_NAME }} | jq '.privateKeyBase64' | tr -d '"' | sed 's/\\n/\n/g' > ~/.ssh/lightsail.pem
+
       - name: Prepare Server For Build
         uses: appleboy/ssh-action@master
         with:
           host: ${{steps.get-lightsail-ip-address.outputs.IP_ADDRESS}}
           username: ${{steps.get-lightsail-username.outputs.USERNAME}}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          key: ~/.ssh/lightsail.pem
           script: |
             rm -rf ~/projectlab/tmp
             mkdir -p ~/projectlab/app
@@ -133,7 +137,7 @@ jobs:
         with:
           username: ${{steps.get-lightsail-username.outputs.USERNAME}}
           server: ${{steps.get-lightsail-ip-address.outputs.IP_ADDRESS}}
-          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh_private_key: ~/.ssh/lightsail.pem
           local_path: "./*"
           remote_path: "/home/admin/projectlab/tmp/"
           args: "-o ConnectTimeout=60"
@@ -145,7 +149,7 @@ jobs:
           command_timeout: 30m
           host: ${{steps.get-lightsail-ip-address.outputs.IP_ADDRESS}}
           username: ${{steps.get-lightsail-username.outputs.USERNAME}}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          key: ~/.ssh/lightsail.pem
           script: |
             chmod +x /home/admin/projectlab/tmp/scripts/setup.sh
             /home/admin/projectlab/tmp/scripts/setup.sh ${{ steps.get-branch.outputs.branch }} ${{ secrets.LITESTREAM_AWS_ACCESS_KEY_ID }} ${{ secrets.LITESTREAM_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/run-deploy.yaml
+++ b/.github/workflows/run-deploy.yaml
@@ -112,14 +112,14 @@ jobs:
 
       - id: get-lightsail-ssh-key
         name: Get Lightsail Private SSH Key
-        run: mkdir ~/.ssh && aws lightsail download-default-key-pair | jq '.privateKeyBase64' | tr -d '"' | sed 's/\\n/\n/g' > ~/.ssh/lightsail.pem
+        run: echo ::set-output name=SSH_PRIVATE_KEY::$(aws lightsail download-default-key-pair | jq -r '.privateKeyBase64' | head -n -1)
 
       - name: Prepare Server For Build
         uses: appleboy/ssh-action@master
         with:
           host: ${{steps.get-lightsail-ip-address.outputs.IP_ADDRESS}}
           username: ${{steps.get-lightsail-username.outputs.USERNAME}}
-          key: ~/.ssh/lightsail.pem
+          key: ${{ steps.get-lightsail-ssh-key.outputs.SSH_PRIVATE_KEY }}
           script: |
             rm -rf ~/projectlab/tmp
             mkdir -p ~/projectlab/app
@@ -137,7 +137,7 @@ jobs:
         with:
           username: ${{steps.get-lightsail-username.outputs.USERNAME}}
           server: ${{steps.get-lightsail-ip-address.outputs.IP_ADDRESS}}
-          ssh_private_key: ~/.ssh/lightsail.pem
+          ssh_private_key: ${{ steps.get-lightsail-ssh-key.outputs.SSH_PRIVATE_KEY }}
           local_path: "./*"
           remote_path: "/home/admin/projectlab/tmp/"
           args: "-o ConnectTimeout=60"
@@ -149,7 +149,7 @@ jobs:
           command_timeout: 30m
           host: ${{steps.get-lightsail-ip-address.outputs.IP_ADDRESS}}
           username: ${{steps.get-lightsail-username.outputs.USERNAME}}
-          key: ~/.ssh/lightsail.pem
+          key: ${{ steps.get-lightsail-ssh-key.outputs.SSH_PRIVATE_KEY }}
           script: |
             chmod +x /home/admin/projectlab/tmp/scripts/setup.sh
             /home/admin/projectlab/tmp/scripts/setup.sh ${{ steps.get-branch.outputs.branch }} ${{ secrets.LITESTREAM_AWS_ACCESS_KEY_ID }} ${{ secrets.LITESTREAM_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Don't require the SSH_PRIVATE_KEY variable on the GitHub workflow actions.