### PR TITLE
#316 - validate that url must not be null in the insert query

### DIFF
--- a/db/migrations/20220523192906_repo_url_multifield/migration.sql
+++ b/db/migrations/20220523192906_repo_url_multifield/migration.sql
@@ -8,15 +8,14 @@
 -- CreateTable
 CREATE TABLE "Repos" (
     "id" INTEGER NOT NULL PRIMARY KEY,
-    "url" TEXT NOT NULL,
+    "url" TEXT NOT NULL UNIQUE,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "projectId" TEXT NOT NULL,
     CONSTRAINT "Repos_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Projects" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 
-INSERT INTO "Repos" ( "url", "createdAt", "updatedAt", "projectId") SELECT "repoUrl", "createdAt", "updatedAt", "id"
-from "Projects";
+INSERT INTO "Repos" ( "url", "createdAt", "updatedAt", "projectId") SELECT "repoUrl", "createdAt", "updatedAt", "id" FROM "Projects" WHERE "repoUrl" IS NOT NULL;
 
 -- RedefineTables
 PRAGMA foreign_keys=OFF;


### PR DESCRIPTION
#### What does this PR do?

This PR solves the issue regarding the repoUrl being null when populating the Repos table

#### What are the relevant tickets?

#316 
