### PR TITLE
#334 - fix search owner autocomplete list

### DIFF
--- a/app/core/components/MultivalueInput/MultivalueField.styles.tsx
+++ b/app/core/components/MultivalueInput/MultivalueField.styles.tsx
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled"
+
+export const MultivalueFieldSpan = styled.span`
+  font-size: 12px;
+  color: #727e8c;
+`

--- a/app/core/components/MultivalueInput/index.tsx
+++ b/app/core/components/MultivalueInput/index.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from "react"
 import { Chip, Grid, TextField } from "@mui/material"
 import { Field } from "react-final-form"
+import { MultivalueFieldSpan } from "./MultivalueField.styles"
 
 interface ProfilesSelectProps {
   name: string
   label: string
+  footer: string
   helperText?: string
 }
 
-export const MultiValueField = ({ name, label }: ProfilesSelectProps) => {
+export const MultiValueField = ({ name, label, footer }: ProfilesSelectProps) => {
   const [inputValue, setInputValue] = useState<string>("")
 
   return (
@@ -31,6 +33,7 @@ export const MultiValueField = ({ name, label }: ProfilesSelectProps) => {
         const isError = touched && normalizedError !== undefined
         return (
           <>
+            <MultivalueFieldSpan>* {footer}</MultivalueFieldSpan>
             <TextField
               label={label}
               error={isError}

--- a/app/core/components/ProjectOwnerField/index.tsx
+++ b/app/core/components/ProjectOwnerField/index.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "blitz"
 import { Autocomplete, TextField } from "@mui/material"
 import { Field } from "react-final-form"
 import getProfiles from "app/profiles/queries/searchProfiles"
+import debounce from "lodash/debounce"
 
 interface ProfilesSelectProps {
   name: string
@@ -15,9 +16,10 @@ export const ProjectOwnerField = ({ name, label, owner, helperText }: ProfilesSe
   const [searchTerm, setSearchTerm] = useState<string>("")
   const [data, { isLoading }] = useQuery(getProfiles, searchTerm, { suspense: false })
   const [value, setValue] = useState(owner)
-  const [inputValue, setInputValue] = useState("")
 
   const profiles = data || []
+
+  const setSearchTermDebounced = debounce(setSearchTerm, 500)
 
   return (
     <Field name={name}>
@@ -29,18 +31,15 @@ export const ProjectOwnerField = ({ name, label, owner, helperText }: ProfilesSe
             id={name}
             loading={isLoading || !data}
             value={value}
-            onChange={(event: any, newValue: any | null, reason) => {
+            onChange={(_, newValue: any | null, reason) => {
               if (reason === "selectOption") {
                 setValue(newValue)
                 input.onChange({ id: newValue.profileId })
               }
             }}
-            inputValue={inputValue}
             isOptionEqualToValue={(option, value) => option.profileId === value.profileId}
             getOptionLabel={(option) => option.name}
-            onInputChange={(event, newInputValue) => {
-              setInputValue(newInputValue)
-            }}
+            onInputChange={(_, value) => setSearchTermDebounced(value)}
             options={profiles}
             renderInput={(params) => (
               <TextField

--- a/app/projects/components/ProjectForm.tsx
+++ b/app/projects/components/ProjectForm.tsx
@@ -89,7 +89,11 @@ export function ProjectForm<S extends z.ZodType<any, any>>(props: FormProps<S>) 
           label="Who is your target user/client"
           placeholder="Millenials"
         />
-        <MultiValueField name="repoUrls" label="Repo URLs" />
+        <MultiValueField
+          name="repoUrls"
+          label="Repo URLs"
+          footer="Type the Repo URL and press Enter to add it to your project. You can add as many URLs as you need."
+        />
         <LabeledTextField
           fullWidth
           style={{ margin: "1em 0" }}


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the issue of the Owner field list when editing a project, now it refreshes based on what the user is typing. This PR also adds a text for the Repos URLs field explaining how can the user add a URL

#### Where should the reviewer start?

Everything can be tested in the Edit project page

#### How should this be manually tested?

- Go to a project page
- Click on edit
- Play with the Owner field, validating that the Autocomplete is fetching new data based on the search term
- Check that the Repo URLs field has the descriptive text

#### What are the relevant tickets?

#334 

#### Screenshots

<img width="908" alt="image" src="https://user-images.githubusercontent.com/96010361/173922879-febadcae-85ab-4ce0-a2b6-d4625d941c88.png">

#### Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [X] I reviewed existing Pull Requests before submitting mine.
