### PR TITLE
Exit script if any setup.sh command fails

### DIFF
--- a/.github/workflows/run-deploy.yaml
+++ b/.github/workflows/run-deploy.yaml
@@ -101,7 +101,7 @@ jobs:
           host: ${{steps.get-lightsail-ip-address.outputs.IP_ADDRESS}}
           username: ${{steps.get-lightsail-username.outputs.USERNAME}}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
+          script_stop: |
             chmod +x /home/admin/projectlab/tmp/scripts/setup.sh
             /home/admin/projectlab/tmp/scripts/setup.sh ${{ steps.get-branch.outputs.branch }} ${{ secrets.DB_URL }}
             rm -rf ~/projectlab/tmp


### PR DESCRIPTION
Currently you need to analyze the output of the `Configure Server` step to see if nothing failed, because the [ssh-action](https://github.com/appleboy/ssh-action) script doesn't care if the commands passed or not. So we are switching to use `script_stop`