### PR TITLE
#338 - add RepoUrl value to the form for blur events

### DIFF
--- a/app/core/components/MultivalueInput/index.tsx
+++ b/app/core/components/MultivalueInput/index.tsx
@@ -42,6 +42,7 @@ export const MultiValueField = ({ name, label, footer }: ProfilesSelectProps) =>
               onKeyDown={(e) => handleEnterKeyPress(e)}
               onChange={(e) => setInputValue(e.target.value)}
               fullWidth
+              onBlur={() => addOption()}
             />
             <Grid
               container


### PR DESCRIPTION
#### What does this PR do?

This PR allow the user to fill in the RepoUrl field just by triggering a blur event, when the user changes the focus the value that is in the RepoUrl field will automatically added.

#### Where should the reviewer start?

Either in the Create or Edit form

#### How should this be manually tested?

- Go to create new project
- Add any value to the RepoUrl field
- Change the focus (click outside the field or press tab)
- Check that the value is added to the chips
- Finish the create project process and check that the RepoUrl has the value
- Repeat the process with the Edit project flow

#### What are the relevant tickets?

#338 

#### Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [X] I reviewed existing Pull Requests before submitting mine.
