### PR TITLE
Fix - #345 - Remove the limit from the queries to get all results from the db

### DIFF
--- a/app/projects/queries/searchProjects.ts
+++ b/app/projects/queries/searchProjects.ts
@@ -206,7 +206,6 @@ export default resolver.pipe(
       AND "Skills".id IS NOT NULL
       GROUP BY "Skills".id
       ORDER BY count DESC
-      LIMIT 10
     `
 
     const disciplineFacets = await db.$queryRaw<FacetOutput[]>`
@@ -228,7 +227,6 @@ export default resolver.pipe(
       AND "Disciplines".id IS NOT NULL
       GROUP BY "Disciplines".id
       ORDER BY count DESC
-      LIMIT 10
     `
 
     const labelFacets = await db.$queryRaw<FacetOutput[]>`
@@ -250,7 +248,6 @@ export default resolver.pipe(
       AND "Labels".id IS NOT NULL
       GROUP BY "Labels".id
       ORDER BY count DESC
-      LIMIT 10
     `
 
     const projectFacets = await db.$queryRaw<ProjectFacetsOutput[]>`


### PR DESCRIPTION
#### What does this PR do?

This PR removes the limits for the `Skills`, `Looking For`, and `Labels` filters, so they list all the options available for the current projects

#### Where should the reviewer start?

In the Homepage

#### How should this be manually tested?

- Go to the Homepage and validate that the filters re listing all possible options, the projects should have 10+ options for each filter to notice the difference

#### What are the relevant tickets?

#345 

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [X] I reviewed existing Pull Requests before submitting mine.
