### PR TITLE
move looking for field

### DIFF
--- a/app/projects/components/ProjectForm.tsx
+++ b/app/projects/components/ProjectForm.tsx
@@ -64,16 +64,17 @@ export function ProjectForm<S extends z.ZodType<any, any>>(props: FormProps<S>) 
       ></TextEditor>
       <LabeledSwitchField
         name="helpWanted"
-        label="Help wanted"
+        label="We need some help"
         initialValues={initialValues ? initialValues.helpWanted : true}
       />
+      <DisciplinesSelect name="disciplines" label="Looking for..." />
 
       {projectformType === "create" && (
         <FormControlLabel
           value="1"
           control={<Switch color="primary" onChange={handleDisplaySwitch} />}
           label="Add more details"
-          labelPlacement="start"
+          labelPlacement="end"
         />
       )}
       {projectformType !== "create" && (
@@ -109,7 +110,6 @@ export function ProjectForm<S extends z.ZodType<any, any>>(props: FormProps<S>) 
           />
         )}
         <SkillsSelect name="skills" label="Skills" />
-        <DisciplinesSelect name="disciplines" label="Looking for..." />
         <LabelsSelect name="labels" label="Labels" />
         {projectformType !== "create" && (
           <InputSelect


### PR DESCRIPTION
<!-- PR title format: `<Feat> - 351 - Move looking for Field` -->

#### What does this PR do?

Move field looking for out of the more details section and place it just after the help wanted.

Also renamed "Help wanted" to "We need some help" as is more clear and friendly

#### Where should the reviewer start?

app/projects/components/ProjectForm.tsx

#### How should this be manually tested?

Go to the new proposal page look the fields and create a new proposal

#### Any background context you want to provide?

<!-- Add any information regarding the PR that the reviewers should know, if necessary. -->

#### What are the relevant tickets?

<!-- Link to issues, related PRs, JIRA issues, etc. -->

#### Screenshots
Before
<img width="1455" alt="Screen Shot 2022-07-05 at 10 33 34" src="https://user-images.githubusercontent.com/46000487/177364497-5cc76210-f6f6-46ae-87ec-64bd130ca095.png">

After
<img width="1488" alt="Screen Shot 2022-07-05 at 10 34 15" src="https://user-images.githubusercontent.com/46000487/177364628-1cc02320-4282-4b12-b710-e9b26dcff5c8.png">
