### PR TITLE
Deprecate github tokens, stop using repository-dispatch action

### DIFF
--- a/.github/workflows/deploy-develop.yaml
+++ b/.github/workflows/deploy-develop.yaml
@@ -7,14 +7,13 @@ defaults:
     shell: bash
 jobs:
   deploy-branch:
-    env:
-      NODE_ENV: production
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch Deploy
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.REPO_DISPACTH_ACCESS_TOKEN }}
-          repository: wizeline/project-lab
-          event-type: deploy
-          client-payload: '{"ref": "${{ github.ref }}", "branch": "development" , "secret_name":"env-development" }'
+    uses: ./.github/workflows/run-deploy.yaml
+    with:
+      branch_name: development
+      github_ref: ${{ github.ref_name }}
+    secrets:
+      AWS_SECRET_NAME: env-development
+      PIPELINE_AWS_ACCESS_KEY_ID: ${{ secrets.PIPELINE_AWS_ACCESS_KEY_ID }}
+      PIPELINE_AWS_SECRET_ACCESS_KEY: ${{ secrets.PIPELINE_AWS_SECRET_ACCESS_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      DB_URL: ${{ secrets.DB_URL }}

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -8,14 +8,12 @@ defaults:
     shell: bash
 jobs:
   deploy-branch:
-    env:
-      NODE_ENV: production
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch Deploy
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.REPO_DISPACTH_ACCESS_TOKEN }}
-          repository: wizeline/project-lab
-          event-type: deploy
-          client-payload: '{"ref": "${{ github.ref }}", "branch": "production" , "secret_name":"env-production" }'
+    with:
+      branch_name: production
+      github_ref: ${{ github.ref }}
+    secrets:
+      AWS_SECRET_NAME: env-production
+      PIPELINE_AWS_ACCESS_KEY_ID: ${{ secrets.PIPELINE_AWS_ACCESS_KEY_ID }}
+      PIPELINE_AWS_SECRET_ACCESS_KEY: ${{ secrets.PIPELINE_AWS_SECRET_ACCESS_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      DB_URL: ${{ secrets.DB_URL }}

--- a/.github/workflows/deploy-rollback.yaml
+++ b/.github/workflows/deploy-rollback.yaml
@@ -11,14 +11,12 @@ defaults:
     shell: bash
 jobs:
   deploy-branch:
-    env:
-      NODE_ENV: production
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch Deploy
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.REPO_DISPACTH_ACCESS_TOKEN }}
-          repository: wizeline/project-lab
-          event-type: deploy
-          client-payload: '{"ref": "${{ github.event.inputs.tag }}", "branch": "production" , "secret_name":"env-production" }'
+    with:
+      branch_name: production
+      github_ref: ${{ github.event.inputs.tag }}
+    secrets:
+      AWS_SECRET_NAME: env-production
+      PIPELINE_AWS_ACCESS_KEY_ID: ${{ secrets.PIPELINE_AWS_ACCESS_KEY_ID }}
+      PIPELINE_AWS_SECRET_ACCESS_KEY: ${{ secrets.PIPELINE_AWS_SECRET_ACCESS_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      DB_URL: ${{ secrets.DB_URL }}

--- a/.github/workflows/run-deploy.yaml
+++ b/.github/workflows/run-deploy.yaml
@@ -1,7 +1,24 @@
 name: Run Deploy
 on:
-  repository_dispatch:
-    types: [deploy]
+  workflow_call:
+    inputs:
+      branch_name:
+        required: true
+        type: string
+      github_ref:
+        required: true
+        type: string
+    secrets:
+      PIPELINE_AWS_ACCESS_KEY_ID:
+        required: true
+      PIPELINE_AWS_SECRET_ACCESS_KEY:
+        required: true
+      SSH_PRIVATE_KEY:
+        required: true
+      DB_URL:
+        required: true
+      AWS_SECRET_NAME:
+        required: true
 defaults:
   run:
     shell: bash
@@ -14,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.client_payload.ref }}
+          ref: ${{ inputs.github_ref }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -25,49 +42,49 @@ jobs:
 
       - name: Get Github Branch
         id: get-branch
-        run: echo ::set-output name=branch::$(echo "${{ github.event.client_payload.branch }}")
+        run: echo ::set-output name=branch::$(echo "${{ inputs.branch_name }}")
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 16
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16
 
       - name: Remove existing .env file
         run: rm -rf .env
 
       - name: Set .env File
         run: |
-          aws secretsmanager get-secret-value --secret-id ${{ github.event.client_payload.secret_name }} | jq -r '.SecretString' | jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" > env-tmp
+          aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_SECRET_NAME }} | jq -r '.SecretString' | jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" > env-tmp
           cp env-tmp .env
 
       - name: Set Up App Domain
         run: |
-          if [ "${{ steps.get-branch.outputs.branch }}" == "production" ]; then
+          if [ "${{ inputs.branch_name }}" == "production" ]; then
             sed -i -e "s/http:\/\/localhost:3000/https:\/\/labs.wizeline.com/g" ./blitz.config.ts
           else
-            sed -i -e "s/http:\/\/localhost:3000/https:\/\/${{ steps.get-branch.outputs.branch }}.labs.wizeline.com/g" ./blitz.config.ts
+            sed -i -e "s/http:\/\/localhost:3000/https:\/\/${{ inputs.branch_name }}.labs.wizeline.com/g" ./blitz.config.ts
           fi
 
       - name: Terraform Change Workspace Lightsail
         uses: dflook/terraform-new-workspace@v1
         with:
           path: "terraform/lightsail/"
-          workspace: ${{ steps.get-branch.outputs.branch }}
+          workspace: ${{ inputs.branch_name }}
 
       - name: Terraform Apply Lightsail
         uses: dflook/terraform-apply@v1
         with:
           path: "terraform/lightsail/"
-          workspace: ${{ steps.get-branch.outputs.branch }}
+          workspace: ${{ inputs.branch_name }}
           auto_approve: true
 
       - id: get-lightsail-username
         name: Get Lightsail Instance Username
-        run: echo ::set-output name=USERNAME::$(aws lightsail get-instance-access-details --instance-name project-lab-${{ steps.get-branch.outputs.branch }} | jq -r '.accessDetails.username')
+        run: echo ::set-output name=USERNAME::$(aws lightsail get-instance-access-details --instance-name project-lab-${{ inputs.branch_name }} | jq -r '.accessDetails.username')
 
       - id: get-lightsail-ip-address
         name: Get Lightsail Instance IP Address
-        run: echo ::set-output name=IP_ADDRESS::$(aws lightsail get-instance-access-details --instance-name project-lab-${{ steps.get-branch.outputs.branch }} | jq -r '.accessDetails.ipAddress')
+        run: echo ::set-output name=IP_ADDRESS::$(aws lightsail get-instance-access-details --instance-name project-lab-${{ inputs.branch_name }} | jq -r '.accessDetails.ipAddress')
 
       - name: Prepare Server For Build
         uses: appleboy/ssh-action@master
@@ -104,19 +121,19 @@ jobs:
           script_stop: true
           script: |
             chmod +x /home/admin/projectlab/tmp/scripts/setup.sh
-            /home/admin/projectlab/tmp/scripts/setup.sh ${{ steps.get-branch.outputs.branch }} ${{ secrets.DB_URL }}
+            /home/admin/projectlab/tmp/scripts/setup.sh ${{ inputs.branch_name }} ${{ secrets.DB_URL }}
             rm -rf ~/projectlab/tmp
 
       - name: Terraform Change Workspace Distribution
         uses: dflook/terraform-new-workspace@v1
         with:
           path: "terraform/distribution/"
-          workspace: ${{ steps.get-branch.outputs.branch }}
+          workspace: ${{ inputs.branch_name }}
 
       - name: Terraform Apply Distribution
         uses: dflook/terraform-apply@v1
         with:
           path: "terraform/distribution/"
-          workspace: ${{ steps.get-branch.outputs.branch }}
+          workspace: ${{ inputs.branch_name }}
           auto_approve: true
           var: lightsail_instance_ip_address=${{steps.get-lightsail-ip-address.outputs.IP_ADDRESS}}


### PR DESCRIPTION
Stop using https://github.com/peter-evans/repository-dispatch
in favor of https://docs.github.com/en/actions/using-workflows/reusing-workflows

#### Any background context you want to provide?

Since George Wachira left, his token is no longer valid, so our CI/CD is failing.

#### What are the relevant tickets?

<!-- Link to issues, related PRs, JIRA issues, etc. -->

#### Screenshots

<!-- Add before and after screenshots or recording of the feature, if available. -->

#### Questions

<!-- List questions or concerns directed to the reviewers, if necessary. -->

#### Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [ ] I reviewed existing Pull Requests before submitting mine.
