### PR TITLE
Allow non admin users to edit project statuses, only tier would remain admin only

### DIFF
--- a/app/projects/components/ProjectForm.tsx
+++ b/app/projects/components/ProjectForm.tsx
@@ -106,7 +106,6 @@ export function ProjectForm<S extends z.ZodType<any, any>>(props: FormProps<S>) 
             defaultValue={defaultStatus}
             name="projectStatus"
             label="Status"
-            disabled={user?.role !== adminRoleName}
           />
         )}
         <SkillsSelect name="skills" label="Skills" />


### PR DESCRIPTION
#### What does this PR do?

This reverts a little changes made for #216 and #212. Only the `tier` field would remain editable by admins, which I think is what we want. Especially if we merge #358, which will "hide" some projects from the homepage (projects with `status != Idea in Progress`).

#### Where should the reviewer start?

<!-- Point out where the reviewer should start to review the code additions or subtractions. -->

#### How should this be manually tested?

<!-- List the steps to reproduce, corroborate, or tests to run. Write this section clear enough so that external developers can also follow it and test the feature or fix. -->

#### Any background context you want to provide?

<!-- Add any information regarding the PR that the reviewers should know, if necessary. -->

#### What are the relevant tickets?

<!-- Link to issues, related PRs, JIRA issues, etc. -->

#### Screenshots

<!-- Add before and after screenshots or recording of the feature, if available. -->

#### Questions

<!-- List questions or concerns directed to the reviewers, if necessary. -->

#### Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [ ] I reviewed existing Pull Requests before submitting mine.
