### PR TITLE
Feat - #348 - change role field to be related to disciplines table

### DIFF
--- a/app/core/components/DisciplinesSelect/index.tsx
+++ b/app/core/components/DisciplinesSelect/index.tsx
@@ -15,6 +15,7 @@ interface DisciplinesSelectProps {
   outerProps?: PropsWithoutRef<JSX.IntrinsicElements["div"]>
   size?: "small" | "medium" | undefined
   style?: object
+  parentName?: string
 }
 
 export const DisciplinesSelect = ({
@@ -27,6 +28,7 @@ export const DisciplinesSelect = ({
   outerProps,
   size,
   style,
+  parentName,
 }: DisciplinesSelectProps) => {
   const [searchTerm, setSearchTerm] = useState<string>("")
 
@@ -44,7 +46,7 @@ export const DisciplinesSelect = ({
 
   const { values } = useFormState()
 
-  if (!values["helpWanted"]) return null
+  if (parentName && !values[parentName]) return null
 
   return (
     <Field name={name}>

--- a/app/core/components/ProjectMembersField/index.tsx
+++ b/app/core/components/ProjectMembersField/index.tsx
@@ -13,6 +13,7 @@ import { Field } from "react-final-form"
 import getProfiles from "app/profiles/queries/searchProfiles"
 import debounce from "lodash/debounce"
 import { SkillsSelect } from "app/core/components/SkillsSelect"
+import { DisciplinesSelect } from "app/core/components/DisciplinesSelect"
 
 interface ProfilesSelectProps {
   name: string
@@ -85,18 +86,35 @@ export const ProjectMembersField = ({ name, label, helperText }: ProfilesSelectP
                       }
                     />
                   </Grid>
-                  <Grid item xs={6} sm={2}>
-                    <TextField
-                      label="Role"
-                      defaultValue={row.role}
-                      size="small"
-                      onChange={(event) => {
-                        row.role = event.target.value
+                  <Grid item xs={12} sm={4}>
+                    <DisciplinesSelect
+                      customOnChange={(value) => {
+                        row.role = value
                         input.onChange(input.value)
                       }}
+                      fullWidth={true}
+                      name={`role-${row.profileId}`}
+                      label="Role(s)"
+                      defaultValue={row.role}
+                      size="small"
+                      style={{ margin: 0 }}
                     />
                   </Grid>
-                  <Grid item xs={6} sm={2}>
+                  <Grid item xs={12} sm={4}>
+                    <SkillsSelect
+                      customOnChange={(value) => {
+                        row.practicedSkills = value
+                        input.onChange(input.value)
+                      }}
+                      defaultValue={row.practicedSkills}
+                      fullWidth={true}
+                      label="Skills"
+                      name={`practicedSkills-${row.profileId}`}
+                      size="small"
+                      style={{ margin: 0 }}
+                    />
+                  </Grid>
+                  <Grid item xs={6} sm={1}>
                     <TextField
                       label="Hours"
                       helperText="H. per week"
@@ -116,21 +134,7 @@ export const ProjectMembersField = ({ name, label, helperText }: ProfilesSelectP
                       }}
                     />
                   </Grid>
-                  <Grid item xs={6} sm={4}>
-                    <SkillsSelect
-                      customOnChange={(value) => {
-                        row.practicedSkills = value
-                        input.onChange(input.value)
-                      }}
-                      defaultValue={row.practicedSkills}
-                      fullWidth={true}
-                      label="Skills"
-                      name={`practicedSkills-${row.profileId}`}
-                      size="small"
-                      style={{ margin: 0 }}
-                    />
-                  </Grid>
-                  <Grid item xs={6} sm={2} style={{ textAlign: "center" }}>
+                  <Grid item xs={6} sm={1} style={{ textAlign: "center" }}>
                     <FormControlLabel
                       label="Active"
                       control={

--- a/app/projects/components/ContributorPathReport/index.tsx
+++ b/app/projects/components/ContributorPathReport/index.tsx
@@ -75,7 +75,7 @@ export const ContributorPathReport = ({ project }: IProps) => {
             <th>Active</th>
             <th>Name</th>
             <th align="center">Email</th>
-            <th>Role</th>
+            <th>Role(s)</th>
             <th>
               H.P.W.
               <br />
@@ -126,7 +126,12 @@ export const ContributorPathReport = ({ project }: IProps) => {
                     </EmailAt>
                   </HtmlTooltip>
                 </td>
-                <td>{member.role}</td>
+                <td>
+                  {member.role.reduce(
+                    (acc, r, idx) => (idx === 0 ? r.name : acc + `, ${r.name}`),
+                    ""
+                  )}
+                </td>
                 <td align="center">{member.hoursPerWeek}</td>
                 {project.stages?.map((stage, s) => (
                   <td key={s}>

--- a/app/projects/components/ProjectForm.tsx
+++ b/app/projects/components/ProjectForm.tsx
@@ -67,7 +67,7 @@ export function ProjectForm<S extends z.ZodType<any, any>>(props: FormProps<S>) 
         label="We need some help"
         initialValues={initialValues ? initialValues.helpWanted : true}
       />
-      <DisciplinesSelect name="disciplines" label="Looking for..." />
+      <DisciplinesSelect name="disciplines" label="Looking for..." parentName="helpWanted" />
 
       {projectformType === "create" && (
         <FormControlLabel

--- a/app/projects/components/joinProjectModal/index.tsx
+++ b/app/projects/components/joinProjectModal/index.tsx
@@ -7,6 +7,7 @@ import Button from "@mui/material/Button"
 
 import useProjectMembers from "app/projects/hooks/useProjectMembers"
 import { SkillsSelect } from "app/core/components/SkillsSelect"
+import { DisciplinesSelect } from "app/core/components/DisciplinesSelect"
 import { Grid, FormDivContainer, CommitmentDivContainer } from "./joinProjectModal.styles"
 import { Routes, useRouter } from "blitz"
 
@@ -17,7 +18,11 @@ interface IProps {
 }
 
 export const JoinFields = z.object({
-  role: z.string(),
+  role: z.array(
+    z.object({
+      id: z.string(),
+    })
+  ),
   hoursPerWeek: z.string().refine((val) => !val || /^\d+$/.test(val), {
     message: "Value must be an integer",
   }),
@@ -36,6 +41,7 @@ const JoinProjectModal = (props: IProps) => {
   const INIT_VALUES_MODALFORM = useMemo(() => {
     return {
       practicedSkills: [],
+      role: [],
     }
   }, [])
 
@@ -70,12 +76,7 @@ const JoinProjectModal = (props: IProps) => {
             <h1>Join Project</h1>
 
             <p className="question">What role will you be playing?</p>
-            <LabeledTextField
-              name="role"
-              fullWidth
-              label="Role"
-              outerProps={{ style: { marginTop: 10, marginBottom: 20 } }}
-            />
+            <DisciplinesSelect name="role" label="Role(s)" />
 
             <p className="question">What's your availability?</p>
             <LabeledTextField

--- a/app/projects/hooks/useProjectMembers.ts
+++ b/app/projects/hooks/useProjectMembers.ts
@@ -12,7 +12,9 @@ const useProjectMembers = () => {
     profileId?: string
     hoursPerWeek: number
     practicedSkills: any[]
-    role: string
+    role: {
+      id: string
+    }[]
   }
   const createProjectMemberHandler = async (object: IProjectMember) => {
     const cpm = await createProjectMemberMutation(object)

--- a/app/projects/mutations/createProjectMember.ts
+++ b/app/projects/mutations/createProjectMember.ts
@@ -10,13 +10,15 @@ export default resolver.pipe(
       return { id: skill.id }
     })
 
+    const rolesArrayConnect = input.role?.map((r) => ({ id: r.id }))
+
     const projectMember = await db.projectMembers.create({
       data: {
         project: { connect: { id: input.projectId } },
         profile: { connect: { id: session.profileId } },
         hoursPerWeek: input.hoursPerWeek,
         practicedSkills: { connect: practicedSkillsArrayConnect },
-        role: input.role,
+        role: { connect: rolesArrayConnect },
       },
     })
     return projectMember

--- a/app/projects/mutations/deleteProject.ts
+++ b/app/projects/mutations/deleteProject.ts
@@ -22,7 +22,7 @@ export default resolver.pipe(
         owner: true,
         projectMembers: {
           include: { profile: { select: { firstName: true, lastName: true } } },
-          orderBy: [{ active: "desc" }, { role: "asc" }],
+          orderBy: [{ active: "desc" }],
         },
       },
     })

--- a/app/projects/mutations/updateProject.ts
+++ b/app/projects/mutations/updateProject.ts
@@ -19,17 +19,23 @@ export default resolver.pipe(
           return { id: skill.id }
         }
       )
+      // Creates the array for the roles connect
+      const rolesArrayConnect = data.projectMembers[index].role?.map((r) => {
+        return { id: r.id }
+      })
       // Create only the members that don't exist in this project
       if (data.projectMembers[index].profile) {
         activeMembers.push(data.projectMembers[index]?.id)
-        // Just disconnects ALL related practicedSkills, so it can UPDATE just the new selected ones after...
+        // Just disconnects ALL related practicedSkills and roles, so it can UPDATE just the new selected ones after...
         await db.projectMembers.update({
           where: { id: data.projectMembers[index].id },
           data: {
             practicedSkills: { set: [] },
+            role: { set: [] },
           },
           include: {
             practicedSkills: true,
+            role: true,
           },
         })
         // Makes all the actual updates to the projectMember
@@ -37,7 +43,7 @@ export default resolver.pipe(
           where: { id: data.projectMembers[index].id },
           data: {
             hoursPerWeek: data.projectMembers[index].hoursPerWeek,
-            role: data.projectMembers[index].role,
+            role: { connect: rolesArrayConnect },
             active: data.projectMembers[index].active,
             practicedSkills: { connect: practicedSkillsArrayConnect },
           },
@@ -51,7 +57,7 @@ export default resolver.pipe(
             project: { connect: { id } },
             profile: { connect: { id: data.projectMembers[index].profileId } },
             hoursPerWeek: data.projectMembers[index].hoursPerWeek,
-            role: data.projectMembers[index].role,
+            role: { connect: rolesArrayConnect },
             practicedSkills: { connect: practicedSkillsArrayConnect },
           },
         })
@@ -120,6 +126,7 @@ export default resolver.pipe(
         projectMembers: {
           include: {
             profile: { select: { firstName: true, lastName: true, email: true } },
+            role: true,
             contributorPath: true,
             practicedSkills: true,
           },

--- a/app/projects/queries/getProject.ts
+++ b/app/projects/queries/getProject.ts
@@ -24,8 +24,9 @@ export default resolver.pipe(
             profile: { select: { firstName: true, lastName: true, email: true } },
             contributorPath: true,
             practicedSkills: true,
+            role: true,
           },
-          orderBy: [{ active: "desc" }, { role: "asc" }],
+          orderBy: [{ active: "desc" }],
         },
         stages: {
           include: {

--- a/app/projects/validations.ts
+++ b/app/projects/validations.ts
@@ -6,7 +6,7 @@ export const InitialMembers = (session) => {
         {
           profileId: session.profileId,
           name: session.name,
-          role: "Owner",
+          role: [{ id: "1", name: "Owner" }],
           active: true,
           hoursPerWeek: 40,
           practicedSkills: [],
@@ -28,7 +28,14 @@ const projectMembers = z
         )
         .optional(),
       profileId: z.string(),
-      role: z.string().nullish(),
+      role: z
+        .array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+          })
+        )
+        .optional(),
       profile: z
         .object({
           firstName: z.string(),
@@ -184,7 +191,7 @@ export const CreateProjectMember = z.object({
   projectId: z.any(),
   hoursPerWeek: z.number(),
   practicedSkills: z.array(z.object({ id: z.string() })),
-  role: z.string(),
+  role: z.array(z.object({ id: z.string() })),
 })
 
 export const UpdateProjectsInoovationTier = z.object({

--- a/db/migrations/20220605211859_add_full_text_search_with_pgsql/migration.sql
+++ b/db/migrations/20220605211859_add_full_text_search_with_pgsql/migration.sql
@@ -48,11 +48,11 @@ CREATE OR REPLACE FUNCTION project_members_versions_fn() RETURNS TRIGGER
   LANGUAGE plpgsql AS $body$
 BEGIN
   IF (TG_OP = 'INSERT') THEN
-    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
-    VALUES (new."projectId", new."profileId", new."hoursPerWeek", new.role, new.active, '');
+    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "active", "practicedSkills")
+    VALUES (new."projectId", new."profileId", new."hoursPerWeek", new.active, '');
   ELSIF (TG_OP = 'UPDATE') THEN
-    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
-    VALUES (new."projectId", new."profileId", new."hoursPerWeek", new.role, new.active, '');
+    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "active", "practicedSkills")
+    VALUES (new."projectId", new."profileId", new."hoursPerWeek", new.active, '');
   ELSIF (TG_OP = 'DELETE') THEN
     INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
     VALUES (old."projectId", old."profileId", 0, '', false, '');

--- a/db/migrations/20220605211859_add_full_text_search_with_pgsql/migration.sql
+++ b/db/migrations/20220605211859_add_full_text_search_with_pgsql/migration.sql
@@ -48,11 +48,11 @@ CREATE OR REPLACE FUNCTION project_members_versions_fn() RETURNS TRIGGER
   LANGUAGE plpgsql AS $body$
 BEGIN
   IF (TG_OP = 'INSERT') THEN
-    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "active", "practicedSkills")
-    VALUES (new."projectId", new."profileId", new."hoursPerWeek", new.active, '');
+    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
+    VALUES (new."projectId", new."profileId", new."hoursPerWeek", new.role, new.active, '');
   ELSIF (TG_OP = 'UPDATE') THEN
-    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "active", "practicedSkills")
-    VALUES (new."projectId", new."profileId", new."hoursPerWeek", new.active, '');
+    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
+    VALUES (new."projectId", new."profileId", new."hoursPerWeek", new.role, new.active, '');
   ELSIF (TG_OP = 'DELETE') THEN
     INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
     VALUES (old."projectId", old."profileId", 0, '', false, '');

--- a/db/migrations/20220708122207_change_disciplines/migration.sql
+++ b/db/migrations/20220708122207_change_disciplines/migration.sql
@@ -1,0 +1,50 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `role` on the `ProjectMembers` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "ProjectMembers" DROP COLUMN "role";
+
+-- CreateTable
+CREATE TABLE "_DisciplinesToProjectMembers" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_DisciplinesToProjectMembers_AB_unique" ON "_DisciplinesToProjectMembers"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_DisciplinesToProjectMembers_B_index" ON "_DisciplinesToProjectMembers"("B");
+
+-- AddForeignKey
+ALTER TABLE "_DisciplinesToProjectMembers" ADD CONSTRAINT "_DisciplinesToProjectMembers_A_fkey" FOREIGN KEY ("A") REFERENCES "Disciplines"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_DisciplinesToProjectMembers" ADD CONSTRAINT "_DisciplinesToProjectMembers_B_fkey" FOREIGN KEY ("B") REFERENCES "ProjectMembers"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+
+CREATE OR REPLACE FUNCTION roles_versions_fn() RETURNS TRIGGER
+  LANGUAGE plpgsql AS $body$
+BEGIN
+  UPDATE "ProjectMembersVersions"
+  SET
+    "updatedAt" = CURRENT_TIMESTAMP,
+    "role" = (SELECT string_agg(_dpm."A", ',') FROM "_DisciplinesToProjectMembers" _dpm WHERE _dpm."B" = new."B")
+  WHERE id = (
+    SELECT v.id FROM "ProjectMembers" pm
+    INNER JOIN "ProjectMembersVersions" v ON pm."profileId" = v."profileId" AND pm."projectId" = v."projectId"
+    WHERE pm.id = new."B"
+    ORDER BY v."createdAt" DESC LIMIT 1
+  );
+  RETURN NULL;
+END;
+$body$;
+
+CREATE TRIGGER roles_versions_trigger
+  AFTER INSERT OR UPDATE
+  ON "_DisciplinesToProjectMembers"
+  FOR EACH ROW
+  EXECUTE FUNCTION roles_versions_fn();

--- a/db/migrations/20220708122207_change_disciplines/migration.sql
+++ b/db/migrations/20220708122207_change_disciplines/migration.sql
@@ -4,10 +4,23 @@
   - You are about to drop the column `role` on the `ProjectMembers` table. All the data in the column will be lost.
 
 */
--- AlterTable
-ALTER TABLE "ProjectMembers" DROP COLUMN "role";
 
 -- CreateTable
+CREATE TABLE "new_ProjectMembers" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "projectId" TEXT NOT NULL,
+    "profileId" TEXT NOT NULL,
+    "hoursPerWeek" INTEGER,
+    "active" BOOLEAN NOT NULL DEFAULT true
+);
+
+INSERT INTO "new_ProjectMembers" ("id","createdAt", "updatedAt", "projectId", "profileId", "hoursPerWeek", "active") SELECT "id", "createdAt", "updatedAt", "projectId", "profileId", "hoursPerWeek", "active" FROM "ProjectMembers";
+
+ALTER TABLE "ProjectMembers" RENAME TO "old_ProjectMembers";
+ALTER TABLE "new_ProjectMembers" RENAME TO "ProjectMembers";
+
 CREATE TABLE "_DisciplinesToProjectMembers" (
     "A" TEXT NOT NULL,
     "B" TEXT NOT NULL
@@ -48,3 +61,169 @@ CREATE TRIGGER roles_versions_trigger
   ON "_DisciplinesToProjectMembers"
   FOR EACH ROW
   EXECUTE FUNCTION roles_versions_fn();
+
+-- Insert new Disciplines
+INSERT INTO "Disciplines" VALUES
+(md5(random()::text), 'Stakeholder'),
+(md5(random()::text), 'Consultant')
+ON CONFLICT do nothing;
+
+-- Procedure to migrate old roles into the new table
+CREATE TABLE temps (
+  old_discipline TEXT,
+  discipline TEXT
+);
+
+INSERT INTO temps VALUES
+('Android developer', 'Android Engineer'),
+('Android Developer', 'Android Engineer'),
+('ANDROID DEVELOPER', 'Android Engineer'),
+('Android Developer/Project Manager', 'Android Engineer'),
+('Android Developer/Tech Lead', 'Android Engineer'),
+('Android Develper', 'Android Engineer'),
+('Android Engineer', 'Android Engineer'),
+('Backend', 'Backend'),
+('Backend Developer', 'Backend'),
+('Backend Engineer', 'Backend'),
+('Backend Engineer/co-leader', 'Backend'),
+('Backend Engineer/ Reviewer', 'Backend'),
+('Backend Engineer/Infrastructure', 'Backend'),
+('Backend/Team Manager', 'Backend'),
+('Backend / Unity Developer', 'Backend'),
+('Business Stakeholder', 'Stakeholder'),
+('Data Engineer', 'Data Engineer'),
+('Data Scientist', 'Data Scientist'),
+('Designer', 'UX Designer'),
+('Devops', 'Site Reliability Engineer'),
+('DevOps', 'Site Reliability Engineer'),
+('FE Developer', 'Frontend'),
+('Frontend', 'Frontend'),
+('Frontend Developer', 'Frontend'),
+('Front End Developer', 'Frontend'),
+('Front-End Developer', 'Frontend'),
+('Frontend Developer/React', 'Frontend'),
+('Frontend Engineer/co-leader', 'Frontend'),
+('Frontend / Unity Developer', 'Frontend'),
+('Fullstack', 'Fullstack'),
+('FullStack', 'Fullstack'),
+(' FullStack', 'Fullstack'),
+('Fullstack Developer', 'Fullstack'),
+('Full Stack Engineer', 'Fullstack'),
+('Functional QA Engineer III', 'Automation QA'),
+('Infraestructure / Backend', 'Backend'),
+('iOS', 'iOS Engineer'),
+('iOS Developer', 'iOS Engineer'),
+('iOS Developer/Backup Team Manager', 'iOS Engineer'),
+('iOS Developer/Tech Lead', 'iOS Engineer'),
+('iOS Engineer', 'iOS Engineer'),
+('Owner', 'Owner'),
+('PM', 'Project Manager'),
+('Project Manager', 'Project Manager'),
+('Product Manager', 'Product Manager'),
+('QA', 'Automation QA'),
+('QA Jr.', 'Automation QA'),
+('SEE', 'Evolution Engineer'),
+('Site Reliability Engineer', 'Site Reliability Engineer'),
+('SRE', 'Site Reliability Engineer'),
+('Tech Lead', 'Tech Lead'),
+('Teach Lead', 'Tech Lead'),
+('Tech Lead Frontend', 'Tech Lead'),
+('Tech Lead QA', 'Tech Lead'),
+('Tech Lead SRE', 'Tech Lead'),
+('Team Manager', 'Tech Lead'),
+('Technical Writer', 'Technical Writer'),
+('Technical writer', 'Technical Writer'),
+('Technical Writer ', 'Technical Writer'),
+('UI/UX Designer', 'UX Designer'),
+('UX', 'UX Designer'),
+('UX designer', 'UX Designer'),
+('Android Developer/Project Manager', 'Project Manager'),
+('Android Developer/Tech Lead', 'Tech Lead'),
+('Backend Engineer/co-leader', 'Tech Lead'),
+('Backend Engineer/Infrastructure', 'Site Reliability Engineer'),
+('Backend/Team Manager', 'Tech Lead'),
+('Frontend Engineer/co-leader', 'Tech Lead'),
+('Infraestructure / Backend', 'Site Reliability Engineer'),
+('iOS Developer/Backup Team Manager', 'Tech Lead'),
+('iOS Developer/Tech Lead', 'Tech Lead'),
+('Developer', 'Fullstack'),
+('Software Engineer', 'Fullstack'),
+('Software Engineering', 'Fullstack'),
+('SWE', 'Fullstack'),
+('UI to YAML', 'Fullstack'),
+('Unity Lead Developer', 'Fullstack'),
+('Unity Lead Developer', 'Tech Lead'),
+('VSCode Ext', 'Fullstack'),
+('Web developer', 'Fullstack');
+
+INSERT INTO "_DisciplinesToProjectMembers" SELECT d.id as "A", pm.id as "B" FROM "Disciplines" d
+	INNER JOIN "temps" te ON d.name = te.discipline
+	INNER JOIN "old_ProjectMembers" pm ON te.old_discipline = pm.role;
+
+DROP TABLE IF EXISTS "temps";
+
+-- Modify ProjectMembersVersions function
+CREATE OR REPLACE FUNCTION project_members_versions_fn() RETURNS TRIGGER
+  LANGUAGE plpgsql AS $body$
+BEGIN
+  IF (TG_OP = 'INSERT') THEN
+    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "active", "practicedSkills")
+    VALUES (new."projectId", new."profileId", new."hoursPerWeek", new.active, '');
+  ELSIF (TG_OP = 'UPDATE') THEN
+    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "active", "practicedSkills")
+    VALUES (new."projectId", new."profileId", new."hoursPerWeek", new.active, '');
+  ELSIF (TG_OP = 'DELETE') THEN
+    INSERT INTO "ProjectMembersVersions"("projectId", "profileId", "hoursPerWeek", "role", "active", "practicedSkills")
+    VALUES (old."projectId", old."profileId", 0, '', false, '');
+  END IF;
+  RETURN NULL;
+END;
+$body$;
+
+/*
+  Warnings:
+
+  - You are about to drop the `old_ProjectMembers` table. If the table is not empty, all the data it contains will be lost.
+  - A unique constraint covering the columns `[projectId,profileId]` on the table `ProjectMembers` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ContributorPath" DROP CONSTRAINT "ContributorPath_projectMemberId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_ProjectMembersToSkills" DROP CONSTRAINT "_ProjectMembersToSkills_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "old_ProjectMembers" DROP CONSTRAINT "ProjectMembers_profileId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "old_ProjectMembers" DROP CONSTRAINT "ProjectMembers_projectId_fkey";
+
+-- AlterTable
+ALTER TABLE "old_ProjectMembers" DROP CONSTRAINT "ProjectMembers_pkey";
+
+ALTER TABLE "ProjectMembers" RENAME CONSTRAINT "new_ProjectMembers_pkey" TO "ProjectMembers_pkey";
+
+-- DropTable
+DROP TABLE "old_ProjectMembers";
+
+-- CreateIndex
+CREATE INDEX "project_members_profile_id_idx" ON "ProjectMembers"("profileId");
+
+-- CreateIndex
+CREATE INDEX "project_members_project_id_idx" ON "ProjectMembers"("projectId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectMembers_projectId_profileId_key" ON "ProjectMembers"("projectId", "profileId");
+
+-- AddForeignKey
+ALTER TABLE "ProjectMembers" ADD CONSTRAINT "ProjectMembers_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectMembers" ADD CONSTRAINT "ProjectMembers_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ContributorPath" ADD CONSTRAINT "ContributorPath_projectMemberId_fkey" FOREIGN KEY ("projectMemberId") REFERENCES "ProjectMembers"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ProjectMembersToSkills" ADD CONSTRAINT "_ProjectMembersToSkills_A_fkey" FOREIGN KEY ("A") REFERENCES "ProjectMembers"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -111,7 +111,7 @@ model ProjectMembers {
   projectId       String
   profileId       String
   hoursPerWeek    Int?
-  role            String?
+  role            Disciplines[]
   active          Boolean           @default(true)
   profile         Profiles?         @relation(fields: [profileId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   project         Projects?         @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -240,11 +240,12 @@ model Skills {
 }
 
 model Disciplines {
-  id        String     @id @default(uuid())
-  name      String     @unique
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @default(now())
-  projects  Projects[]
+  id             String           @id @default(uuid())
+  name           String           @unique
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @default(now())
+  projects       Projects[]
+  projectMembers ProjectMembers[]
 
   @@index([name], name: "discipline_name_idx")
 }

--- a/db/seeds.prod.ts
+++ b/db/seeds.prod.ts
@@ -114,6 +114,11 @@ const seed = async () => {
     update: {},
     create: { name: "Intern" },
   })
+  await db.disciplines.upsert({
+    where: { name: "Owner" },
+    update: {},
+    create: { name: "Owner" },
+  })
 
   await db.innovationTiers.upsert({
     where: { name: "Tier 3 (Experiment)" },

--- a/db/seeds.prod.ts
+++ b/db/seeds.prod.ts
@@ -119,6 +119,16 @@ const seed = async () => {
     update: {},
     create: { name: "Owner" },
   })
+  await db.disciplines.upsert({
+    where: { name: "Stakeholder" },
+    update: {},
+    create: { name: "Stakeholder" },
+  })
+  await db.disciplines.upsert({
+    where: { name: "Consultant" },
+    update: {},
+    create: { name: "Consultant" },
+  })
 
   await db.innovationTiers.upsert({
     where: { name: "Tier 3 (Experiment)" },

--- a/db/seeds.ts
+++ b/db/seeds.ts
@@ -508,7 +508,9 @@ const seed = async () => {
             {
               profile: { connect: { id: jp.id } },
               hoursPerWeek: 3,
-              role: "Tech Lead",
+              role: {
+                connect: [{ name: "Tech Lead" }],
+              },
             },
           ],
         },
@@ -546,27 +548,37 @@ const seed = async () => {
             {
               profile: { connect: { id: jbc.id } },
               hoursPerWeek: 3,
-              role: "Frontend",
+              role: {
+                connect: [{ name: "Frontend" }],
+              },
             },
             {
               profile: { connect: { id: tejeda.id } },
               hoursPerWeek: 3,
-              role: "Backend",
+              role: {
+                connect: [{ name: "Backend" }],
+              },
             },
             {
               profile: { connect: { id: george.id } },
               hoursPerWeek: 3,
-              role: "SRE",
+              role: {
+                connect: [{ name: "Site Reliability Engineer" }],
+              },
             },
             {
               profile: { connect: { id: jquiroz.id } },
               hoursPerWeek: 3,
-              role: "Frontend",
+              role: {
+                connect: [{ name: "Frontend" }],
+              },
             },
             {
               profile: { connect: { id: jamj.id } },
               hoursPerWeek: 3,
-              role: "Frontend",
+              role: {
+                connect: [{ name: "Frontend" }],
+              },
               practicedSkills: {
                 connect: [
                   { id: "b27f5e6c-4470-4f83-8fd6-dc097e127f44" },
@@ -613,7 +625,9 @@ const seed = async () => {
             {
               profile: { connect: { id: ev.id } },
               hoursPerWeek: 3,
-              role: "Tech Lead",
+              role: {
+                connect: [{ name: "Tech Lead" }],
+              },
             },
           ],
         },
@@ -650,7 +664,9 @@ const seed = async () => {
             {
               profile: { connect: { id: b.id } },
               hoursPerWeek: 3,
-              role: "Tech Lead",
+              role: {
+                connect: [{ name: "Tech Lead" }],
+              },
             },
           ],
         },
@@ -694,7 +710,9 @@ const seed = async () => {
             {
               profile: { connect: { id: enoc.id } },
               hoursPerWeek: 3,
-              role: "Tech Lead",
+              role: {
+                connect: [{ name: "Tech Lead" }],
+              },
             },
           ],
         },


### PR DESCRIPTION
#### What does this PR do?

This PR modifies the Create, Edit and Join Project forms, so the `Role` field is no longer an open string field but a field related to the `Disciplines` table values, the user must can only select options from the list provided.

It also migrate most of the old role values to the new structure so the users don't have to re-enter this info, however, there are some cases where certain users will have to do it as we can't relate the current value to the `Disciplines` records.

Last but not least, I added the `Owner` and `Stakeholder` option to the `Disciplines` table.

#### Where should the reviewer start?

In any of the form listed above

#### How should this be manually tested?

- Create a new project
- Go to edit the project and confirm that the `Owner` is assigned correctly
- In this page, add new users, add new roles, delete existing roles, and validate that the roles are being assigned modified correctly
- Go to an existing project and try to join, select different roles and submit the form, validate that the roles selected are applied correctly

#### What are the relevant tickets?

#348

#### Screenshots

<img width="1371" alt="image" src="https://user-images.githubusercontent.com/96010361/178767278-09d8b463-da30-4fc9-b475-3b59ef4b9c34.png">

<img width="867" alt="image" src="https://user-images.githubusercontent.com/96010361/178767474-4aa66251-ddee-447c-8cbc-2a3835238e97.png">


#### Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [X] I reviewed existing Pull Requests before submitting mine.
