### PR TITLE
Show the members number

### DIFF
--- a/app/core/components/ProposalCard/ProposalCard.styles.tsx
+++ b/app/core/components/ProposalCard/ProposalCard.styles.tsx
@@ -117,6 +117,18 @@ export const ProposalCardWrap = styled.div`
       margin-left: 3px;
     }
   }
+  .ProposalCard__status--members {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    color: #000000;
+    font-size: 14px;
+    margin-right: 10px;
+
+    & span {
+      margin-left: 3px;
+    }
+  }
   .ProposalCard__head__description--tier {
     font-weight: 700;
     font-size: 12px;

--- a/app/core/components/ProposalCard/index.tsx
+++ b/app/core/components/ProposalCard/index.tsx
@@ -3,9 +3,9 @@ import { Link, Routes } from "blitz"
 import { CardActionArea, CardContent, Card } from "@mui/material"
 import EllipsisText from "app/core/components/EllipsisText"
 import ThumbUpIcon from "@mui/icons-material/ThumbUp"
-import QuestionMarkIcon from "@mui/icons-material/QuestionMark"
 import HelpIcon from "@mui/icons-material/Help"
 import Image from "next/image"
+import PersonIcon from "@mui/icons-material/Person"
 
 import { ProposalCardWrap } from "./ProposalCard.styles"
 
@@ -22,6 +22,7 @@ interface IProps {
   skills?: { name: string }[]
   isOwner?: boolean
   tierName: String
+  projectMembers?: number | null
 }
 
 export const ProposalCard = (props: IProps) => {
@@ -93,11 +94,19 @@ export const ProposalCard = (props: IProps) => {
                         </label>
                       </div>
                     </div>
-                    <div className="ProposalCard__status--like">
-                      <p>{props.votesCount} </p>
-                      <span>
-                        <ThumbUpIcon sx={{ color: "#AF2E33", fontSize: 15 }} />
-                      </span>
+                    <div>
+                      <div className="ProposalCard__status--like">
+                        <p>{props.votesCount} </p>
+                        <span>
+                          <ThumbUpIcon sx={{ color: "#AF2E33", fontSize: 15 }} />
+                        </span>
+                      </div>
+                      <div className="ProposalCard__status--members">
+                        <p>{props.projectMembers} </p>
+                        <span>
+                          <PersonIcon sx={{ color: "#000000", fontSize: 15 }} />
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/app/pages/projects/search.tsx
+++ b/app/pages/projects/search.tsx
@@ -129,6 +129,7 @@ export const Projects = () => {
         }
         isOwner={item.ownerId === user.profileId}
         tierName={item.tierName}
+        projectMembers={item.projectMembers}
       />
     )
   }

--- a/app/projects/components/ContributorPathReport/index.tsx
+++ b/app/projects/components/ContributorPathReport/index.tsx
@@ -68,7 +68,7 @@ export const IncompleteIcon = styled.span`
 export const ContributorPathReport = ({ project }: IProps) => {
   return (
     <>
-      <big>Contributors</big>
+      <big>Contributors ({project.projectMembers.length})</big>
       <table width="100%" className="table-project-members">
         <thead>
           <tr>

--- a/app/projects/components/ContributorPathReport/index.tsx
+++ b/app/projects/components/ContributorPathReport/index.tsx
@@ -68,7 +68,15 @@ export const IncompleteIcon = styled.span`
 export const ContributorPathReport = ({ project }: IProps) => {
   return (
     <>
-      <big>Contributors ({project.projectMembers.length})</big>
+      <big>
+        Contributors (
+        {
+          project.projectMembers.filter((member) => {
+            return member.active
+          }).length
+        }{" "}
+        active)
+      </big>
       <table width="100%" className="table-project-members">
         <thead>
           <tr>


### PR DESCRIPTION
show the members number in card and detail pages

<!-- PR title format: `Feat - NA- Show the number of members` -->


#### What does this PR do?

Show the number of members of a project in the card and in the contribution section

#### Where should the reviewer start?

Any of the files

#### How should this be manually tested?

Create a project add some members and the number of members should be shown

#### Any background context you want to provide?

This feature will help in innovation camp.

#### Screenshots

Before:
<img width="322" alt="Screen Shot 2022-08-31 at 18 18 13" src="https://user-images.githubusercontent.com/46000487/187801344-f0be5f1e-7346-457f-a182-295c10a7ebeb.png">


after:
<img width="301" alt="Screen Shot 2022-08-31 at 18 19 40" src="https://user-images.githubusercontent.com/46000487/187801469-a9890bda-5a62-4bfa-a1c4-ada97949f2f3.png">


<img width="1359" alt="Screen Shot 2022-08-31 at 18 19 57" src="https://user-images.githubusercontent.com/46000487/187801501-93568273-03d6-47f9-9c9e-f1ada0d92f1f.png">


